### PR TITLE
Temporary fix to allow publish of Signer

### DIFF
--- a/.github/workflows/publish-casper-signer.yml
+++ b/.github/workflows/publish-casper-signer.yml
@@ -23,11 +23,16 @@ jobs:
     - run: npm install
     - run: npm audit --audit-level=low
     - run: npm run complete
-    - name: Publish Extension
-      uses: trmcnvn/chrome-addon@v2
-      with:
-        extension: 'djhndpllfiibmcdbnmaaahkhchcoijce'
-        zip: "artifacts/casperlabs_signer-0.3.5.zip"
-        client-id: ${{ secrets.client_id }}
-        client-secret: ${{ secrets.client_secret }}
-        refresh-token: ${{ secrets.refresh_token }}
+    - name: Get latest Signer version number
+      id: get_signer_version
+      uses: battila7/get-version-action@v2
+      run: echo ${{ steps.get_signer_version.outputs.version }}
+      run: echo ${{ steps.get_signer_version.outputs.version-without-v }}
+    # - name: Publish Extension
+    #   uses: trmcnvn/chrome-addon@v2
+    #   with:
+    #     extension: 'djhndpllfiibmcdbnmaaahkhchcoijce'
+    #     zip: artifacts/casperlabs_signer-${{ steps.get_signer_version.outputs.version }}.zip
+    #     client-id: ${{ secrets.client_id }}
+    #     client-secret: ${{ secrets.client_secret }}
+    #     refresh-token: ${{ secrets.refresh_token }}

--- a/.github/workflows/publish-casper-signer.yml
+++ b/.github/workflows/publish-casper-signer.yml
@@ -27,7 +27,7 @@ jobs:
       uses: trmcnvn/chrome-addon@v2
       with:
         extension: 'djhndpllfiibmcdbnmaaahkhchcoijce'
-        zip: "artifacts/casperlabs_signer-*.zip"
+        zip: "artifacts/casperlabs_signer-0.3.5.zip"
         client-id: ${{ secrets.client_id }}
         client-secret: ${{ secrets.client_secret }}
         refresh-token: ${{ secrets.refresh_token }}

--- a/.github/workflows/publish-casper-signer.yml
+++ b/.github/workflows/publish-casper-signer.yml
@@ -26,13 +26,11 @@ jobs:
     - name: Get latest Signer version number
       id: get_signer_version
       uses: battila7/get-version-action@v2
-      run: echo ${{ steps.get_signer_version.outputs.version }}
-      run: echo ${{ steps.get_signer_version.outputs.version-without-v }}
-    # - name: Publish Extension
-    #   uses: trmcnvn/chrome-addon@v2
-    #   with:
-    #     extension: 'djhndpllfiibmcdbnmaaahkhchcoijce'
-    #     zip: artifacts/casperlabs_signer-${{ steps.get_signer_version.outputs.version }}.zip
-    #     client-id: ${{ secrets.client_id }}
-    #     client-secret: ${{ secrets.client_secret }}
-    #     refresh-token: ${{ secrets.refresh_token }}
+    - name: Publish Extension
+      uses: trmcnvn/chrome-addon@v2
+      with:
+        extension: 'djhndpllfiibmcdbnmaaahkhchcoijce'
+        zip: artifacts/casperlabs_signer-${{ steps.get_signer_version.outputs.version-without-v }}.zip
+        client-id: ${{ secrets.client_id }}
+        client-secret: ${{ secrets.client_secret }}
+        refresh-token: ${{ secrets.refresh_token }}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "build": "npm run build_ui && npm run build_scripts",
     "watch": "node watch.js",
     "scripts_watch": "export INLINE_RUNTIME_CHUNK=false && webpack --watch",
-    "package": "rm -rf ./artifacts/* && web-ext build --config=webext.config.js",
+    "package": "web-ext build --config=webext.config.js",
     "complete": "npm run build && npm run package",
     "test": "react-scripts test",
     "test_ci": "react-scripts test --watchAll=false",


### PR DESCRIPTION
Hardcodes the file name so we can get the new Signer published.
Removes the unnecessary file deletion from the `npm run package` script as this is done as part of the `web-ext build` command due to the `overwriteDest` config entry.