### PR TITLE
ECO-1015: Add Salting to Passwords

### DIFF
--- a/custom-test-env.js
+++ b/custom-test-env.js
@@ -1,0 +1,14 @@
+const Environment = require('jest-environment-jsdom');
+
+/**
+ * A custom environment to set the TextEncoder that is required by TensorFlow.js.
+ */
+module.exports = class CustomTestEnvironment extends Environment {
+  async setup() {
+    await super.setup();
+    if (typeof this.global.TextEncoder === 'undefined') {
+      const { TextEncoder } = require('util');
+      this.global.TextEncoder = TextEncoder;
+    }
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -31567,9 +31567,9 @@
       }
     },
     "node_modules/y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -57059,9 +57059,9 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "scripts_watch": "export INLINE_RUNTIME_CHUNK=false && webpack --watch",
     "package": "web-ext build --config=webext.config.js",
     "complete": "npm run build && npm run package",
-    "test": "react-scripts test",
+    "test": "react-scripts test --env=./custom-test-env.js",
     "test_ci": "react-scripts test --watchAll=false",
     "lint": "eslint .",
     "eject": "react-scripts eject"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "package": "web-ext build --config=webext.config.js",
     "complete": "npm run build && npm run package",
     "test": "react-scripts test --env=./custom-test-env.js",
-    "test_ci": "react-scripts test --watchAll=false",
+    "test_ci": "react-scripts test --watchAll=false --env=./custom-test-env.js",
     "lint": "eslint .",
     "eject": "react-scripts eject"
   },

--- a/src/background/AuthController.test.ts
+++ b/src/background/AuthController.test.ts
@@ -54,94 +54,101 @@ describe('AuthController', () => {
     ).resolves.toBeUndefined();
   });
 
-  test('it should be able to create a new vault only once with password', async () => {
-    await expect(authController.createNewVault(password)).rejects.toThrow();
-  });
+  // test('it should be able to create a new vault only once with password', async () => {
+  //   await expect(authController.createNewVault(password)).rejects.toThrow();
+  // });
 
-  test('it should be able to lock and unlock using correct password', async () => {
-    expect(authController.isUnlocked).toBeTruthy();
+  // test('it should be able to lock and unlock using correct password', async () => {
+  //   expect(authController.isUnlocked).toBeTruthy();
+  //   await authController.lock();
+  //   expect(authController.isUnlocked).toBeFalsy();
+  //   await expect(authController.unlock(wrongPassword)).rejects.toThrow();
+  //   await authController.unlock(password);
+  //   expect(authController.isUnlocked).toBeTruthy();
+
+  //   // make sure we have fixed https://github.com/CasperLabs/CasperLabs/pull/1821#discussion_r409650020
+  //   await authController.importUserAccount(
+  //     'account1',
+  //     encodeBase64(nacl.sign_keyPair().secretKey)
+  //   );
+
+  //   await authController.lock();
+  //   await authController.unlock(password);
+  //   expect(authController.isUnlocked).toBeTruthy();
+  // });
+
+  // it('should be able to add new account and failed when either name or private key duplicated', async () => {
+  //   let signKeyPair1 = nacl.sign_keyPair();
+  //   let duplicateAccountName = 'account1';
+  //   await expect(
+  //     authController.importUserAccount(
+  //       duplicateAccountName,
+  //       encodeBase64(signKeyPair1.secretKey)
+  //     )
+  //   ).resolves.toBeUndefined;
+  //   let signKeyPair2 = nacl.sign_keyPair();
+  //   await expect(
+  //     authController.importUserAccount(
+  //       duplicateAccountName,
+  //       encodeBase64(signKeyPair2.secretKey)
+  //     )
+  //   ).rejects.toThrow(/same name/g);
+  //   await expect(
+  //     authController.importUserAccount(
+  //       'new name',
+  //       encodeBase64(signKeyPair1.secretKey)
+  //     )
+  //   ).rejects.toThrow(/same private key/g);
+  // });
+
+  // it('should be able to switch account by account name', async () => {
+  //   const switchAccount1 = 'switch_account1';
+  //   const switchAccount2 = 'switch_account2';
+  //   await authController.importUserAccount(
+  //     switchAccount1,
+  //     encodeBase64(nacl.sign_keyPair().secretKey)
+  //   );
+  //   await authController.importUserAccount(
+  //     switchAccount2,
+  //     encodeBase64(nacl.sign_keyPair().secretKey)
+  //   );
+
+  //   expect(appState.selectedUserAccount?.name).toBe(switchAccount2);
+
+  //   authController.switchToAccount(switchAccount1);
+  //   expect(appState.selectedUserAccount?.name).toBe(switchAccount1);
+
+  //   expect(() => {
+  //     authController.switchToAccount('not_exist');
+  //   }).toThrow(/doesn't exist/g);
+  // });
+
+  // it('should be able to save and restore userAccounts and selectUserAccount information', async () => {
+  //   await authController.importUserAccount(
+  //     'account1',
+  //     encodeBase64(nacl.sign_keyPair().secretKey)
+  //   );
+  //   await authController.importUserAccount(
+  //     'account2',
+  //     encodeBase64(nacl.sign_keyPair().secretKey)
+  //   );
+
+  //   // restore from storage
+  //   const anotherState = new AppState();
+  //   const anotherAuthContainer = new AuthController(anotherState);
+  //   await anotherAuthContainer.unlock(password);
+
+  //   // jest.toEqual is deep equal
+  //   expect(anotherState.userAccounts).toEqual(appState.userAccounts);
+  //   expect(anotherState.selectedUserAccount).toEqual(
+  //     appState.selectedUserAccount
+  //   );
+  // });
+
+  it('Lock and unlock successfully', async () => {
     await authController.lock();
-    expect(authController.isUnlocked).toBeFalsy();
-    await expect(authController.unlock(wrongPassword)).rejects.toThrow();
-    await authController.unlock(password);
-    expect(authController.isUnlocked).toBeTruthy();
-
-    // make sure we have fixed https://github.com/CasperLabs/CasperLabs/pull/1821#discussion_r409650020
-    await authController.importUserAccount(
-      'account1',
-      encodeBase64(nacl.sign_keyPair().secretKey)
-    );
-
-    await authController.lock();
-    await authController.unlock(password);
-    expect(authController.isUnlocked).toBeTruthy();
-  });
-
-  it('should be able to add new account and failed when either name or private key duplicated', async () => {
-    let signKeyPair1 = nacl.sign_keyPair();
-    let duplicateAccountName = 'account1';
-    await expect(
-      authController.importUserAccount(
-        duplicateAccountName,
-        encodeBase64(signKeyPair1.secretKey)
-      )
-    ).resolves.toBeUndefined;
-    let signKeyPair2 = nacl.sign_keyPair();
-    await expect(
-      authController.importUserAccount(
-        duplicateAccountName,
-        encodeBase64(signKeyPair2.secretKey)
-      )
-    ).rejects.toThrow(/same name/g);
-    await expect(
-      authController.importUserAccount(
-        'new name',
-        encodeBase64(signKeyPair1.secretKey)
-      )
-    ).rejects.toThrow(/same private key/g);
-  });
-
-  it('should be able to switch account by account name', async () => {
-    const switchAccount1 = 'switch_account1';
-    const switchAccount2 = 'switch_account2';
-    await authController.importUserAccount(
-      switchAccount1,
-      encodeBase64(nacl.sign_keyPair().secretKey)
-    );
-    await authController.importUserAccount(
-      switchAccount2,
-      encodeBase64(nacl.sign_keyPair().secretKey)
-    );
-
-    expect(appState.selectedUserAccount?.name).toBe(switchAccount2);
-
-    authController.switchToAccount(switchAccount1);
-    expect(appState.selectedUserAccount?.name).toBe(switchAccount1);
-
-    expect(() => {
-      authController.switchToAccount('not_exist');
-    }).toThrow(/doesn't exist/g);
-  });
-
-  it('should be able to save and restore userAccounts and selectUserAccount information', async () => {
-    await authController.importUserAccount(
-      'account1',
-      encodeBase64(nacl.sign_keyPair().secretKey)
-    );
-    await authController.importUserAccount(
-      'account2',
-      encodeBase64(nacl.sign_keyPair().secretKey)
-    );
-
-    // restore from storage
-    const anotherState = new AppState();
-    const anotherAuthContainer = new AuthController(anotherState);
-    await anotherAuthContainer.unlock(password);
-
-    // jest.toEqual is deep equal
-    expect(anotherState.userAccounts).toEqual(appState.userAccounts);
-    expect(anotherState.selectedUserAccount).toEqual(
-      appState.selectedUserAccount
-    );
+    expect(authController.isUnlocked).toEqual(false);
+    await authController.unlock('correct_password');
+    expect(authController.isUnlocked).toEqual(true);
   });
 });

--- a/src/background/AuthController.test.ts
+++ b/src/background/AuthController.test.ts
@@ -54,101 +54,94 @@ describe('AuthController', () => {
     ).resolves.toBeUndefined();
   });
 
-  // test('it should be able to create a new vault only once with password', async () => {
-  //   await expect(authController.createNewVault(password)).rejects.toThrow();
-  // });
+  test('it should be able to create a new vault only once with password', async () => {
+    await expect(authController.createNewVault(password)).rejects.toThrow();
+  });
 
-  // test('it should be able to lock and unlock using correct password', async () => {
-  //   expect(authController.isUnlocked).toBeTruthy();
-  //   await authController.lock();
-  //   expect(authController.isUnlocked).toBeFalsy();
-  //   await expect(authController.unlock(wrongPassword)).rejects.toThrow();
-  //   await authController.unlock(password);
-  //   expect(authController.isUnlocked).toBeTruthy();
-
-  //   // make sure we have fixed https://github.com/CasperLabs/CasperLabs/pull/1821#discussion_r409650020
-  //   await authController.importUserAccount(
-  //     'account1',
-  //     encodeBase64(nacl.sign_keyPair().secretKey)
-  //   );
-
-  //   await authController.lock();
-  //   await authController.unlock(password);
-  //   expect(authController.isUnlocked).toBeTruthy();
-  // });
-
-  // it('should be able to add new account and failed when either name or private key duplicated', async () => {
-  //   let signKeyPair1 = nacl.sign_keyPair();
-  //   let duplicateAccountName = 'account1';
-  //   await expect(
-  //     authController.importUserAccount(
-  //       duplicateAccountName,
-  //       encodeBase64(signKeyPair1.secretKey)
-  //     )
-  //   ).resolves.toBeUndefined;
-  //   let signKeyPair2 = nacl.sign_keyPair();
-  //   await expect(
-  //     authController.importUserAccount(
-  //       duplicateAccountName,
-  //       encodeBase64(signKeyPair2.secretKey)
-  //     )
-  //   ).rejects.toThrow(/same name/g);
-  //   await expect(
-  //     authController.importUserAccount(
-  //       'new name',
-  //       encodeBase64(signKeyPair1.secretKey)
-  //     )
-  //   ).rejects.toThrow(/same private key/g);
-  // });
-
-  // it('should be able to switch account by account name', async () => {
-  //   const switchAccount1 = 'switch_account1';
-  //   const switchAccount2 = 'switch_account2';
-  //   await authController.importUserAccount(
-  //     switchAccount1,
-  //     encodeBase64(nacl.sign_keyPair().secretKey)
-  //   );
-  //   await authController.importUserAccount(
-  //     switchAccount2,
-  //     encodeBase64(nacl.sign_keyPair().secretKey)
-  //   );
-
-  //   expect(appState.selectedUserAccount?.name).toBe(switchAccount2);
-
-  //   authController.switchToAccount(switchAccount1);
-  //   expect(appState.selectedUserAccount?.name).toBe(switchAccount1);
-
-  //   expect(() => {
-  //     authController.switchToAccount('not_exist');
-  //   }).toThrow(/doesn't exist/g);
-  // });
-
-  // it('should be able to save and restore userAccounts and selectUserAccount information', async () => {
-  //   await authController.importUserAccount(
-  //     'account1',
-  //     encodeBase64(nacl.sign_keyPair().secretKey)
-  //   );
-  //   await authController.importUserAccount(
-  //     'account2',
-  //     encodeBase64(nacl.sign_keyPair().secretKey)
-  //   );
-
-  //   // restore from storage
-  //   const anotherState = new AppState();
-  //   const anotherAuthContainer = new AuthController(anotherState);
-  //   await anotherAuthContainer.unlock(password);
-
-  //   // jest.toEqual is deep equal
-  //   expect(anotherState.userAccounts).toEqual(appState.userAccounts);
-  //   expect(anotherState.selectedUserAccount).toEqual(
-  //     appState.selectedUserAccount
-  //   );
-  // });
-
-  it('Lock and unlock successfully', async () => {
+  test('it should be able to lock and unlock using correct password', async () => {
+    expect(authController.isUnlocked).toBeTruthy();
     await authController.lock();
-    expect(authController.isUnlocked).toEqual(false);
-    await authController.unlock('correct_password');
-    expect(authController.isUnlocked).toEqual(true);
+    expect(authController.isUnlocked).toBeFalsy();
+    await expect(authController.unlock(wrongPassword)).rejects.toThrow();
+    await authController.unlock(password);
+    expect(authController.isUnlocked).toBeTruthy();
+
+    // make sure we have fixed https://github.com/CasperLabs/CasperLabs/pull/1821#discussion_r409650020
+    await authController.importUserAccount(
+      'account1',
+      encodeBase64(nacl.sign_keyPair().secretKey)
+    );
+
+    await authController.lock();
+    await authController.unlock(password);
+    expect(authController.isUnlocked).toBeTruthy();
+  });
+
+  it('should be able to add new account and failed when either name or private key duplicated', async () => {
+    let signKeyPair1 = nacl.sign_keyPair();
+    let duplicateAccountName = 'account1';
+    await expect(
+      authController.importUserAccount(
+        duplicateAccountName,
+        encodeBase64(signKeyPair1.secretKey)
+      )
+    ).resolves.toBeUndefined;
+    let signKeyPair2 = nacl.sign_keyPair();
+    await expect(
+      authController.importUserAccount(
+        duplicateAccountName,
+        encodeBase64(signKeyPair2.secretKey)
+      )
+    ).rejects.toThrow(/same name/g);
+    await expect(
+      authController.importUserAccount(
+        'new name',
+        encodeBase64(signKeyPair1.secretKey)
+      )
+    ).rejects.toThrow(/same private key/g);
+  });
+
+  it('should be able to switch account by account name', async () => {
+    const switchAccount1 = 'switch_account1';
+    const switchAccount2 = 'switch_account2';
+    await authController.importUserAccount(
+      switchAccount1,
+      encodeBase64(nacl.sign_keyPair().secretKey)
+    );
+    await authController.importUserAccount(
+      switchAccount2,
+      encodeBase64(nacl.sign_keyPair().secretKey)
+    );
+
+    expect(appState.selectedUserAccount?.name).toBe(switchAccount2);
+
+    authController.switchToAccount(switchAccount1);
+    expect(appState.selectedUserAccount?.name).toBe(switchAccount1);
+
+    expect(() => {
+      authController.switchToAccount('not_exist');
+    }).toThrow(/doesn't exist/g);
+  });
+
+  it('should be able to save and restore userAccounts and selectUserAccount information', async () => {
+    await authController.importUserAccount(
+      'account1',
+      encodeBase64(nacl.sign_keyPair().secretKey)
+    );
+    await authController.importUserAccount(
+      'account2',
+      encodeBase64(nacl.sign_keyPair().secretKey)
+    );
+
+    // restore from storage
+    const anotherState = new AppState();
+    const anotherAuthContainer = new AuthController(anotherState);
+    await anotherAuthContainer.unlock(password);
+
+    // jest.toEqual is deep equal
+    expect(anotherState.userAccounts).toEqual(appState.userAccounts);
+    expect(anotherState.selectedUserAccount).toEqual(
+      appState.selectedUserAccount
+    );
   });
 });

--- a/src/background/AuthController.ts
+++ b/src/background/AuthController.ts
@@ -292,7 +292,7 @@ class AuthController {
 
   /**
    * Helper function to convert a string into a Uint8array
-   * @param str string to get bytes of
+   * @param {string} str to get bytes of
    */
   private stringToBytes(str: string) {
     return new TextEncoder().encode(str);

--- a/src/background/AuthController.ts
+++ b/src/background/AuthController.ts
@@ -19,25 +19,30 @@ interface PersistentVaultData {
 }
 
 class AuthController {
-  // we store hashed password instead of original password
+  // we store the salted password hash instead of original password
   private passwordHash: string | null = null;
+  private passwordSalt: Uint8Array | null = null;
 
-  // we will use the passwordHash above to encrypt the valut object
-  // and then using this key to store it in local storage
+  // we will use the passwordHash above to encrypt the value object
+  // and then using this key to store it in local storage along with
+  // the plain text salt for the password.
   private encryptedVaultKey = 'encryptedVault';
+  private saltKey = 'passwordSalt';
 
   constructor(private appState: AppState) {
-    if (this.getEncryptedVault()) {
+    if (this.getStoredValueWithKey(this.encryptedVaultKey) !== null) {
       this.appState.hasCreatedVault = true;
     }
   }
 
   @action.bound
   async createNewVault(password: string): Promise<void> {
-    if (this.getEncryptedVault()) {
+    if (this.getStoredValueWithKey(this.encryptedVaultKey) !== null) {
       throw new Error('There is a vault already');
     }
-    const hash = this.hash(password);
+    let [salt, saltedPassword] = this.saltPassword(password);
+    let hash = this.hash(saltedPassword);
+    this.passwordSalt = salt;
     this.passwordHash = hash;
     await this.clearAccount();
     await this.persistVault();
@@ -234,7 +239,9 @@ class AuthController {
   }
 
   /**
-   * encrypted userAccounts by using passwordHash, and save it to local storage.
+   * Encrypt user accounts using salted password hash.
+   * Save the encryptedVault string to the store.
+   * Save the plain text passwordSalt to the store.
    */
   private async persistVault() {
     const encryptedVault = await passworder.encrypt(this.passwordHash!, {
@@ -245,34 +252,94 @@ class AuthController {
         ? this.serializeSignKeyPairWithAlias(this.appState.selectedUserAccount)
         : null
     });
-    this.saveEncryptedVault(encryptedVault);
-  }
 
-  private getEncryptedVault() {
-    return store.get(this.encryptedVaultKey);
-  }
-
-  private saveEncryptedVault(encryptedVault: string) {
-    store.set(this.encryptedVaultKey, encryptedVault);
-  }
-
-  private async restoreVault(password: string): Promise<PersistentVaultData> {
-    let encryptedVault = this.getEncryptedVault();
-    if (!encryptedVault) {
-      throw new Error('There is no vault');
-    }
-    const vault = await passworder.decrypt(password, encryptedVault);
-    return vault as PersistentVaultData;
+    this.saveKeyValuetoStore(this.encryptedVaultKey, encryptedVault);
+    this.saveKeyValuetoStore(this.saltKey, this.passwordSalt!);
   }
 
   /**
-   * Hash the user input password for storing locally
-   * @param str
+   * Saves a given value under a given key in the store.
+   * @param key Key to save value under in store.
+   * @param value Value to save under Key in store.
    */
-  private hash(str: string) {
-    const b = Buffer.from(str);
-    const h = nacl.hash(Uint8Array.from(b));
-    return encodeBase64(h);
+  private saveKeyValuetoStore(key: string, value: any) {
+    store.set(key, value);
+  }
+
+  /**
+   * Get a stored value by key. If no key exists then return null.
+   * @param key Key under which value is stored.
+   * @returns Stored value by given key.
+   */
+  private getStoredValueWithKey(key: string) {
+    return store.get(key, null);
+  }
+
+  private async restoreVault(
+    password: string
+  ): Promise<[PersistentVaultData, string]> {
+    let encryptedVault = this.getStoredValueWithKey(this.encryptedVaultKey);
+    if (!encryptedVault) {
+      throw new Error('There is no vault');
+    }
+    let storedSalt = this.getStoredValueWithKey(this.saltKey);
+    let [, saltedPassword] = this.saltPassword(password, storedSalt);
+    let saltedPasswordHash = this.hash(saltedPassword);
+
+    const vault = await passworder.decrypt(saltedPasswordHash, encryptedVault);
+    return [vault as PersistentVaultData, saltedPasswordHash];
+  }
+
+  /**
+   * Helper function to convert a string into a Uint8array
+   * @param str string to get bytes of
+   */
+  private stringToBytes(str: string) {
+    let buff = Buffer.from(str);
+    return Uint8Array.from(buff);
+  }
+
+  /**
+   * Generate a salted password for hashing.
+   * @param {string} password for salting.
+   * @param  {Uint8Array} [salt=null] will use instead of random bytes if provided.
+   * @returns {Uint8Array} Salt bytes.
+   * @returns {Uint8Array} Salted password bytes.
+   */
+  private saltPassword(
+    password: string,
+    salt: Uint8Array | null = null
+  ): [Uint8Array, Uint8Array] {
+    let passwordSalt: Uint8Array;
+    salt !== null
+      ? (passwordSalt = salt)
+      : (passwordSalt = nacl.randomBytes(64));
+    let passwordBytes = this.stringToBytes(password);
+    let saltedPasswordBytes = new Uint8Array(
+      passwordSalt.length + passwordBytes.length
+    );
+    saltedPasswordBytes.set(passwordSalt);
+    saltedPasswordBytes.set(passwordBytes, passwordSalt.length);
+    // TODO: Remove console.logs once bug is fixed
+    console.log(`\
+      Salt Stored?\t    : ${salt !== null ? 'Yes' : 'No'}\n\
+      Salt:\t\t ${passwordSalt.length} : ${encodeBase64(passwordSalt)}\n\
+      Password:\t ${passwordBytes.length} : ${encodeBase64(passwordBytes)}\n\
+      S.Password:\t ${saltedPasswordBytes.length} : ${encodeBase64(
+      saltedPasswordBytes
+    )}\n\
+    `);
+    return [passwordSalt, saltedPasswordBytes];
+  }
+
+  /**
+   * Hash given bytes and encodes in base64
+   * @param {Uint8Array} bytes Bytes for hashing.
+   * @returns {String} Base64 encoded hash.
+   */
+  private hash(bytes: Uint8Array) {
+    let hashedBytes = nacl.hash(bytes);
+    return encodeBase64(hashedBytes);
   }
 
   /*
@@ -292,9 +359,9 @@ class AuthController {
    */
   @action.bound
   async unlock(password: string) {
-    const passwordHash = this.hash(password);
-    const vault = await this.restoreVault(passwordHash);
-    this.passwordHash = passwordHash;
+    let vaultResponse = await this.restoreVault(password);
+    let vault = vaultResponse[0];
+    this.passwordHash = vaultResponse[1];
     this.appState.isUnlocked = true;
     this.appState.userAccounts.replace(
       vault.userAccounts.map(this.deserializeSignKeyPairWithAlias)

--- a/src/background/AuthController.ts
+++ b/src/background/AuthController.ts
@@ -319,15 +319,6 @@ class AuthController {
     );
     saltedPasswordBytes.set(passwordSalt);
     saltedPasswordBytes.set(passwordBytes, passwordSalt.length);
-    // TODO: Remove console.logs once bug is fixed
-    console.log(`\
-      Salt Stored?\t    : ${salt !== null ? 'Yes' : 'No'}\n\
-      Salt:\t\t ${passwordSalt.length} : ${encodeBase64(passwordSalt)}\n\
-      Password:\t ${passwordBytes.length} : ${encodeBase64(passwordBytes)}\n\
-      S.Password:\t ${saltedPasswordBytes.length} : ${encodeBase64(
-      saltedPasswordBytes
-    )}\n\
-    `);
     return [passwordSalt, saltedPasswordBytes];
   }
 

--- a/src/background/AuthController.ts
+++ b/src/background/AuthController.ts
@@ -295,8 +295,7 @@ class AuthController {
    * @param str string to get bytes of
    */
   private stringToBytes(str: string) {
-    let buff = Buffer.from(str);
-    return Uint8Array.from(buff);
+    return new TextEncoder().encode(str);
   }
 
   /**
@@ -312,7 +311,7 @@ class AuthController {
   ): [Uint8Array, Uint8Array] {
     let passwordSalt: Uint8Array;
     salt !== null
-      ? (passwordSalt = salt)
+      ? (passwordSalt = Uint8Array.from(Object.values(salt)))
       : (passwordSalt = nacl.randomBytes(64));
     let passwordBytes = this.stringToBytes(password);
     let saltedPasswordBytes = new Uint8Array(

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -50,6 +50,7 @@ const App = (props: AppProps) => {
                 homeContainer={props.homeContainer}
                 connectionContainer={props.connectSignerContainer}
                 popupManager={props.popupManager}
+                errors={props.errors}
               />
             )}
           />

--- a/src/popup/components/Home.tsx
+++ b/src/popup/components/Home.tsx
@@ -12,6 +12,7 @@ import AccountManager from '../container/AccountManager';
 import PopupManager from '../../background/PopupManager';
 import { HomeContainer } from '../container/HomeContainer';
 import ConnectSignerContainer from '../container/ConnectSignerContainer';
+import ErrorContainer from '../container/ErrorContainer';
 import { observer } from 'mobx-react';
 import Pages from './Pages';
 import { confirm } from './Confirmation';
@@ -37,6 +38,7 @@ interface Props extends RouteComponentProps, WithStyles<typeof styles> {
   homeContainer: HomeContainer;
   connectionContainer: ConnectSignerContainer;
   popupManager: PopupManager;
+  errors: ErrorContainer;
 }
 
 @observer
@@ -219,6 +221,7 @@ class Home extends React.Component<Props, {}> {
                     try {
                       await this.props.authContainer.unlock(password);
                       this.props.homeContainer.homeForm.$.setPasswordField.reset();
+                      this.props.errors.dismissLast();
                     } catch (e) {
                       this.props.homeContainer.homeForm.$.setPasswordField.setError(
                         e.message

--- a/src/popup/components/Home.tsx
+++ b/src/popup/components/Home.tsx
@@ -175,7 +175,11 @@ class Home extends React.Component<Props, {}> {
     confirm(
       <div className="text-danger">Danger!</div>,
       'Resetting vault will delete all imported accounts.'
-    ).then(() => this.props.authContainer.resetVault());
+    ).then(() => {
+      this.props.authContainer.resetVault();
+      this.props.errors.dismissLast();
+      this.props.homeContainer.homeForm.$.setPasswordField.reset();
+    });
   }
 
   renderUnlock() {


### PR DESCRIPTION
Ticket: [ECO-1015](https://casperlabs.atlassian.net/browse/ECO-1015?atlOrigin=eyJpIjoiMjA0NGFjMDZjMTliNGVkMGExNTgwYzQzYmExYWFkYzAiLCJwIjoiaiJ9)
In this PR:
- Updates dependency `y18n` to fix this [high severity vulnerability](https://www.npmjs.com/advisories/1654) (prototype pollution).
- Implements 'salting' for passwords.
- Fixes the persistent error message issue raised by Michael in [ECO-1004](https://casperlabs.atlassian.net/browse/ECO-1004?atlOrigin=eyJpIjoiMjcwNzY2ZWU2OTJjNGNlMzhjNGU4MjJjM2VmNzFmZmEiLCJwIjoiaiJ9) with commit _[4029940](https://github.com/casper-ecosystem/signer/pull/36/commits/40299401cb56c1d95c5b83ce0b1a2e527a2b47c3)_