### PR TITLE
Remove "Tabs" permission from manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ Icon?
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.vscode

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -29,7 +29,7 @@
       "all_frames": true
     }
   ],
-  "permissions": ["notifications", "tabs"],
+  "permissions": ["notifications"],
   "web_accessible_resources": [
     "scripts/content/inpage.js",
     "scripts/content/signerTestMethods.js",

--- a/watch.js
+++ b/watch.js
@@ -23,10 +23,12 @@ const config = configFactory("development");
 
 // The classic webpack-dev-server can't be used to develop browser extensions,
 // so we remove the "webpackHotDevClient" from the config "entry" point.
-config.entry = config.entry.filter(function(entry) {
-  return !entry.includes("webpackHotDevClient");
-});
-
+if (config.entry.filter) {
+  config.entry = config.entry.filter(function(entry) {
+    return !entry.includes("webpackHotDevClient");
+  });
+}
+  
 // Edit the Webpack config by setting the output directory to "./build".
 config.output.path = paths.appBuild;
 paths.publicUrl = paths.appBuild + "/";


### PR DESCRIPTION
This PR should help fix the publishing flow.
It also fixes the watch command `npm run watch`