### PR TITLE
ECO-1043: Adds Confirmation for User Connecting via Toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "0.3.6",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31023,9 +31023,9 @@
       }
     },
     "node_modules/webpack/node_modules/ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dependencies": {
         "figgy-pudding": "^3.5.1"
       }
@@ -56150,9 +56150,9 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",

--- a/src/popup/components/ConfirmConnect.tsx
+++ b/src/popup/components/ConfirmConnect.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { confirm } from './Confirmation';
+
+export default function confirmConnect() {
+  return confirm(
+    <div className="text-danger">Approve Connection</div>,
+    <div>
+      Connecting allows this site to:
+      <br />
+      <ul>
+        <li>View your selected public key.</li>
+        <li>Make signing requests.</li>
+      </ul>
+      are you sure you want to connect?
+    </div>,
+    'Connect',
+    'Cancel'
+  );
+}

--- a/src/popup/components/ConnectSignerPage.tsx
+++ b/src/popup/components/ConnectSignerPage.tsx
@@ -5,6 +5,7 @@ import { Redirect, RouteComponentProps, withRouter } from 'react-router-dom';
 import { browser } from 'webextension-polyfill-ts';
 import ConnectSignerContainer from '../container/ConnectSignerContainer';
 import Pages from './Pages';
+import { confirm } from './Confirmation';
 
 interface Props extends RouteComponentProps {
   connectSignerContainer: ConnectSignerContainer;
@@ -49,9 +50,24 @@ class ConnectSignerPage extends React.Component<Props, {}> {
               </Grid>
               <Grid item>
                 <Button
-                  onClick={() =>
-                    this.props.connectSignerContainer.connectToSite()
-                  }
+                  onClick={() => {
+                    confirm(
+                      <div className="text-danger">Approve Connection</div>,
+                      <div>
+                        Connecting allows this site to:
+                        <br />
+                        <ul>
+                          <li>View your selected public key.</li>
+                          <li>Make signing requests.</li>
+                        </ul>
+                        are you sure you want to connect?
+                      </div>,
+                      'Connect',
+                      'Cancel'
+                    ).then(() =>
+                      this.props.connectSignerContainer.connectToSite()
+                    );
+                  }}
                   variant="contained"
                   color="primary"
                 >

--- a/src/popup/components/ConnectSignerPage.tsx
+++ b/src/popup/components/ConnectSignerPage.tsx
@@ -5,7 +5,7 @@ import { Redirect, RouteComponentProps, withRouter } from 'react-router-dom';
 import { browser } from 'webextension-polyfill-ts';
 import ConnectSignerContainer from '../container/ConnectSignerContainer';
 import Pages from './Pages';
-import { confirm } from './Confirmation';
+import confirmConnect from './ConfirmConnect';
 
 interface Props extends RouteComponentProps {
   connectSignerContainer: ConnectSignerContainer;
@@ -51,20 +51,7 @@ class ConnectSignerPage extends React.Component<Props, {}> {
               <Grid item>
                 <Button
                   onClick={() => {
-                    confirm(
-                      <div className="text-danger">Approve Connection</div>,
-                      <div>
-                        Connecting allows this site to:
-                        <br />
-                        <ul>
-                          <li>View your selected public key.</li>
-                          <li>Make signing requests.</li>
-                        </ul>
-                        are you sure you want to connect?
-                      </div>,
-                      'Connect',
-                      'Cancel'
-                    ).then(() =>
+                    confirmConnect().then(() =>
                       this.props.connectSignerContainer.connectToSite()
                     );
                   }}

--- a/src/popup/components/MainAppBar.tsx
+++ b/src/popup/components/MainAppBar.tsx
@@ -7,7 +7,7 @@ import AccountManager from '../container/AccountManager';
 import ConnectSignerContainer from '../container/ConnectSignerContainer';
 import { observer } from 'mobx-react';
 import { AppBar, Toolbar, IconButton, Button } from '@material-ui/core';
-import { confirm } from './Confirmation';
+import confirmConnect from './ConfirmConnect';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -58,20 +58,7 @@ export const MainAppBar = observer((props: Props) => {
                 if (connected) {
                   props.connectionContainer.disconnectFromSite();
                 } else {
-                  confirm(
-                    <div className="text-danger">Approve Connection</div>,
-                    <div>
-                      Connecting allows this site to:
-                      <br />
-                      <ul>
-                        <li>View your selected public key.</li>
-                        <li>Make signing requests.</li>
-                      </ul>
-                      are you sure you want to connect?
-                    </div>,
-                    'Connect',
-                    'Cancel'
-                  ).then(() => {
+                  confirmConnect().then(() => {
                     props.connectionContainer.connectToSite();
                   });
                 }

--- a/src/popup/components/MainAppBar.tsx
+++ b/src/popup/components/MainAppBar.tsx
@@ -7,6 +7,7 @@ import AccountManager from '../container/AccountManager';
 import ConnectSignerContainer from '../container/ConnectSignerContainer';
 import { observer } from 'mobx-react';
 import { AppBar, Toolbar, IconButton, Button } from '@material-ui/core';
+import { confirm } from './Confirmation';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -57,7 +58,14 @@ export const MainAppBar = observer((props: Props) => {
                 if (connected) {
                   props.connectionContainer.disconnectFromSite();
                 } else {
-                  props.connectionContainer.connectToSite();
+                  confirm(
+                    <div className="text-danger">Approve Connection</div>,
+                    'Connecting allows this site to access your vault, are you sure you want to connect?',
+                    'Connect',
+                    'Cancel'
+                  ).then(() => {
+                    props.connectionContainer.connectToSite();
+                  });
                 }
               }}
             >

--- a/src/popup/components/MainAppBar.tsx
+++ b/src/popup/components/MainAppBar.tsx
@@ -60,7 +60,15 @@ export const MainAppBar = observer((props: Props) => {
                 } else {
                   confirm(
                     <div className="text-danger">Approve Connection</div>,
-                    'Connecting allows this site to access your vault, are you sure you want to connect?',
+                    <div>
+                      Connecting allows this site to:
+                      <br />
+                      <ul>
+                        <li>View your selected public key.</li>
+                        <li>Make signing requests.</li>
+                      </ul>
+                      are you sure you want to connect?
+                    </div>,
                     'Connect',
                     'Cancel'
                   ).then(() => {


### PR DESCRIPTION
This PR adds a confirmation dialog for when users toggle the button to connect from with the Signer. It should ensure users are aware of the purpose and risks of connecting to the current site.

![Signer Connection Confirmation](https://user-images.githubusercontent.com/69711689/114908369-f19b8300-9e13-11eb-9e68-4ab0e9efadd6.png)

It goes against my original plan for [ECO-1043](https://casperlabs.atlassian.net/browse/ECO-1043?atlOrigin=eyJpIjoiMjc4YzQ2MmZkZWIyNGQ4YzlkNjIyYWEzOGFhMTJkN2QiLCJwIjoiaiJ9), which was to hide the toggle unless the extension was open on a known client i.e. Clarity/CSPR.live/make.services etc.
The reason for the change is that the initial method would require permission to  `Chrome.tabs` in the extension's manifest. In the past changes to these permissions result in scrutiny from the Google team which can delay/cause issues for publishing.