### PR TITLE
ECO-1037: Better handling of connecting when there are no accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "casperlabs-signer",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.13.0",
         "@material-ui/core": "^4.11.0",
@@ -31023,9 +31023,9 @@
       }
     },
     "node_modules/webpack/node_modules/ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dependencies": {
         "figgy-pudding": "^3.5.1"
       }
@@ -56150,9 +56150,9 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",

--- a/src/background/ConnectionManager.ts
+++ b/src/background/ConnectionManager.ts
@@ -13,6 +13,10 @@ export default class ConnectionManager {
   }
 
   public requestConnection() {
+    if (this.appState.userAccounts.length === 0) {
+      this.popupManager.openPopup('noAccount');
+      return;
+    }
     this.appState.connectionRequested = true;
     this.popupManager.openPopup('connect');
   }

--- a/src/background/SignMessageManager.ts
+++ b/src/background/SignMessageManager.ts
@@ -69,10 +69,10 @@ export default class SignMessageManager extends events.EventEmitter {
   public getSelectedPublicKeyBase64() {
     return new Promise((resolve, reject) => {
       let publicKey = this.appState.selectedUserAccount?.signKeyPair.publicKey;
-      if (publicKey === undefined) {
-        return reject(new Error('Please create an account first.'));
-      } else if (!this.appState.connectionStatus) {
+      if (!this.appState.connectionStatus) {
         return reject(new Error('Please connect to the Signer first.'));
+      } else if (publicKey === undefined) {
+        return reject(new Error('Please create an account first.'));
       }
       // ! syntax to satisfy compiler as undefined public key is handled above
       return resolve(encodeBase64(publicKey!));

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -58,7 +58,10 @@ const App = (props: AppProps) => {
             exact
             path={Pages.AccountManagement}
             render={_ => (
-              <AccountManagementPage authContainer={props.authContainer} />
+              <AccountManagementPage
+                authContainer={props.authContainer}
+                connectionContainer={props.connectSignerContainer}
+              />
             )}
           />
           <Route

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import {
   List,
   ListItem,
@@ -12,7 +13,8 @@ import {
   Input,
   Snackbar,
   ListSubheader,
-  Typography
+  Typography,
+  Tooltip
 } from '@material-ui/core';
 import RootRef from '@material-ui/core/RootRef';
 import {
@@ -30,6 +32,7 @@ import { observer, Observer } from 'mobx-react';
 import Dialog from '@material-ui/core/Dialog';
 import { confirm } from './Confirmation';
 import copy from 'copy-to-clipboard';
+import Pages from './Pages';
 
 // interface Item {
 //   id: string;
@@ -63,6 +66,7 @@ export const AccountManagementPage = observer((props: Props) => {
   /* Note: 01 prefix denotes algorithm used in key generation */
   const address = '01' + publicKeyHex;
   const [copyStatus, setCopyStatus] = React.useState(false);
+  const history = useHistory();
 
   const handleClickOpen = (account: SignKeyPairWithAlias) => {
     setOpenDialog(true);
@@ -117,7 +121,15 @@ export const AccountManagementPage = observer((props: Props) => {
     confirm(
       <div className="text-danger">Remove account</div>,
       'Are you sure you want to remove this account?'
-    ).then(() => props.authContainer.removeUserAccount(name));
+    )
+      .then(() => props.authContainer.removeUserAccount(name))
+      .then(() => {
+        // If there are no users accounts left after deletion then
+        // redirect to the home screen
+        if (!(props.authContainer.userAccounts.length > 0)) {
+          history.push(Pages.Home);
+        }
+      });
   };
 
   return (
@@ -149,31 +161,37 @@ export const AccountManagementPage = observer((props: Props) => {
                           >
                             <ListItemText primary={item.name} />
                             <ListItemSecondaryAction>
-                              <IconButton
-                                aria-label="Button will open a dialog to rename key"
-                                edge={'end'}
-                                onClick={() => {
-                                  handleClickOpen(item);
-                                }}
-                              >
-                                <EditIcon />
-                              </IconButton>
-                              <IconButton
-                                edge={'end'}
-                                onClick={() => {
-                                  handleClickRemove(item.name);
-                                }}
-                              >
-                                <DeleteIcon />
-                              </IconButton>
-                              <IconButton
-                                edge={'end'}
-                                onClick={() => {
-                                  handleViewKey(item.name);
-                                }}
-                              >
-                                <VpnKeyIcon />
-                              </IconButton>
+                              <Tooltip title="Edit">
+                                <IconButton
+                                  aria-label="Button will open a dialog to rename key"
+                                  edge={'end'}
+                                  onClick={() => {
+                                    handleClickOpen(item);
+                                  }}
+                                >
+                                  <EditIcon />
+                                </IconButton>
+                              </Tooltip>
+                              <Tooltip title="Delete">
+                                <IconButton
+                                  edge={'end'}
+                                  onClick={() => {
+                                    handleClickRemove(item.name);
+                                  }}
+                                >
+                                  <DeleteIcon />
+                                </IconButton>
+                              </Tooltip>
+                              <Tooltip title="View">
+                                <IconButton
+                                  edge={'end'}
+                                  onClick={() => {
+                                    handleViewKey(item.name);
+                                  }}
+                                >
+                                  <VpnKeyIcon />
+                                </IconButton>
+                              </Tooltip>
                             </ListItemSecondaryAction>
                           </ListItem>
                         )}

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -188,8 +188,8 @@ export const AccountManagementPage = observer((props: Props) => {
                                   </IconButton>
                                 </Tooltip>
                               ) : (
+                                // span is required for tooltip to work on disabled button
                                 <Tooltip title="Can't delete only account">
-                                  {/* span required to wrap disabled button for the tooltip to work */}
                                   <span>
                                     <IconButton edge={'end'} disabled>
                                       <DeleteIcon />

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -176,16 +176,27 @@ export const AccountManagementPage = observer((props: Props) => {
                                   <EditIcon />
                                 </IconButton>
                               </Tooltip>
-                              <Tooltip title="Delete">
-                                <IconButton
-                                  edge={'end'}
-                                  onClick={() => {
-                                    handleClickRemove(item.name);
-                                  }}
-                                >
-                                  <DeleteIcon />
-                                </IconButton>
-                              </Tooltip>
+                              {props.authContainer.userAccounts.length > 1 ? (
+                                <Tooltip title="Delete">
+                                  <IconButton
+                                    edge={'end'}
+                                    onClick={() => {
+                                      handleClickRemove(item.name);
+                                    }}
+                                  >
+                                    <DeleteIcon />
+                                  </IconButton>
+                                </Tooltip>
+                              ) : (
+                                <Tooltip title="Can't delete only account">
+                                  {/* span required to wrap disabled button for the tooltip to work */}
+                                  <span>
+                                    <IconButton edge={'end'} disabled>
+                                      <DeleteIcon />
+                                    </IconButton>
+                                  </span>
+                                </Tooltip>
+                              )}
                               <Tooltip title="View">
                                 <IconButton
                                   edge={'end'}

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -28,6 +28,7 @@ import EditIcon from '@material-ui/icons/Edit';
 import VpnKeyIcon from '@material-ui/icons/VpnKey';
 import FilterNoneIcon from '@material-ui/icons/FilterNone'; // Used for Copy
 import AccountManager from '../container/AccountManager';
+import ConnectSignerContainer from '../container/ConnectSignerContainer';
 import { observer, Observer } from 'mobx-react';
 import Dialog from '@material-ui/core/Dialog';
 import { confirm } from './Confirmation';
@@ -51,6 +52,7 @@ const getItemStyle = (isDragging: boolean, draggableStyle: any) => ({
 
 interface Props {
   authContainer: AccountManager;
+  connectionContainer: ConnectSignerContainer;
 }
 
 export const AccountManagementPage = observer((props: Props) => {
@@ -123,10 +125,12 @@ export const AccountManagementPage = observer((props: Props) => {
       'Are you sure you want to remove this account?'
     )
       .then(() => props.authContainer.removeUserAccount(name))
-      .then(() => {
+      .then(async () => {
         // If there are no users accounts left after deletion then
+        // disconnect from the site and
         // redirect to the home screen
         if (!(props.authContainer.userAccounts.length > 0)) {
+          await props.connectionContainer.disconnectFromSite();
           history.push(Pages.Home);
         }
       });

--- a/src/popup/components/Home.tsx
+++ b/src/popup/components/Home.tsx
@@ -5,8 +5,12 @@ import {
   createStyles,
   FormControl,
   Theme,
-  WithStyles
+  WithStyles,
+  Typography,
+  withStyles,
+  Grid
 } from '@material-ui/core';
+import AddCircleIcon from '@material-ui/icons/AddCircle';
 import { Link, Redirect } from 'react-router-dom';
 import AccountManager from '../container/AccountManager';
 import PopupManager from '../../background/PopupManager';
@@ -18,9 +22,6 @@ import Pages from './Pages';
 import { confirm } from './Confirmation';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { TextFieldWithFormState } from './Forms';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import withStyles from '@material-ui/core/styles/withStyles';
 
 /* eslint-disable jsx-a11y/anchor-is-valid */
 const styles = (theme: Theme) =>
@@ -124,21 +125,30 @@ class Home extends React.Component<Props, {}> {
           justify={'flex-start'}
           alignItems={'center'}
         >
-          <Grid item className={this.props.classes.alignCenter}>
-            <img src={logo} alt="logo" width={120} />
-            <Typography variant={'h6'} align={'center'}>
-              You have {this.props.authContainer.userAccounts.length} account
-              key(s)
-            </Typography>
-            {this.props.authContainer.selectedUserAccount && (
+          {this.props.authContainer.userAccounts.length > 0 ? (
+            <Grid item className={this.props.classes.alignCenter}>
+              <img src={logo} alt="logo" width={120} />
               <Typography variant={'h6'} align={'center'}>
-                Active key:{' '}
-                <span style={{ wordBreak: 'break-all' }}>
-                  {this.props.authContainer.selectedUserAccount.name}
-                </span>
+                You have {this.props.authContainer.userAccounts.length} account
+                key(s)
               </Typography>
-            )}
-          </Grid>
+              {this.props.authContainer.selectedUserAccount && (
+                <Typography variant={'h6'} align={'center'}>
+                  Active key:{' '}
+                  <span style={{ wordBreak: 'break-all' }}>
+                    {this.props.authContainer.selectedUserAccount.name}
+                  </span>
+                </Typography>
+              )}
+            </Grid>
+          ) : (
+            <Grid item className={this.props.classes.alignCenter}>
+              <AddCircleIcon style={{ color: '#e24c2c', fontSize: '4rem' }} />
+              <Typography variant={'h5'} align={'center'}>
+                Please create or import an account to get started
+              </Typography>
+            </Grid>
+          )}
 
           <Grid item>
             <FormControl fullWidth className={this.props.classes.margin}>

--- a/src/popup/components/Menu.tsx
+++ b/src/popup/components/Menu.tsx
@@ -61,7 +61,9 @@ const MoreMenu = observer((props: Props) => {
           aria-labelledby="nested-list-subheader"
           subheader={
             <ListSubheader component="div" id="nested-list-subheader">
-              Accounts
+              {props.authContainer.userAccounts.length > 0
+                ? 'Accounts'
+                : 'No Account'}
             </ListSubheader>
           }
         >


### PR DESCRIPTION
Changes the UI so that instead of showing "You have 0 accounts" - to say "Please create or import an account to get started" as a CTA to encourage users instead of just stating the number of accounts.  

![Signer Add Account CTA](https://user-images.githubusercontent.com/69711689/114941190-bd878880-9e3a-11eb-835b-ae725a0af5ef.png)

Checks for an account before trying to connect - will open on the main where the user will be prompted to add an account as above.
Adds tooltips to the Account Management page buttons to improve UI/UX.
If an account is deleted leaving 0 accounts the extension will disconnect and return to the main page - previously neither of these things happened.