### PR TITLE
Fix Address format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "0.3.6",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -31023,9 +31023,9 @@
       }
     },
     "node_modules/webpack/node_modules/ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dependencies": {
         "figgy-pudding": "^3.5.1"
       }
@@ -56150,9 +56150,9 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -30,6 +30,7 @@ import { observer, Observer } from 'mobx-react';
 import Dialog from '@material-ui/core/Dialog';
 import { confirm } from './Confirmation';
 import copy from 'copy-to-clipboard';
+import { encodeBase64, decodeBase64, Keys } from 'casper-client-sdk';
 
 // interface Item {
 //   id: string;
@@ -59,9 +60,9 @@ export const AccountManagementPage = observer((props: Props) => {
   ] = React.useState<SignKeyPairWithAlias | null>(null);
   const [name, setName] = React.useState('');
   const [publicKey64, setPublicKey64] = React.useState('');
-  const [publicKeyHex, setPublicKeyHex] = React.useState('');
-  /* Note: 01 prefix denotes algorithm used in key generation */
-  const address = '01' + publicKeyHex;
+  const accountAddress = encodeBase64(
+    Keys.Ed25519.accountHash(decodeBase64(publicKey64))
+  );
   const [copyStatus, setCopyStatus] = React.useState(false);
 
   const handleClickOpen = (account: SignKeyPairWithAlias) => {
@@ -74,10 +75,8 @@ export const AccountManagementPage = observer((props: Props) => {
     let publicKey64 = await props.authContainer.getSelectedAccountKey(
       accountName
     );
-    let publicKeyHex = await props.authContainer.getPublicKeyHex(accountName);
     setName(accountName);
     setPublicKey64(publicKey64);
-    setPublicKeyHex(publicKeyHex);
     setOpenKeyDialog(true);
   };
 
@@ -233,14 +232,14 @@ export const AccountManagementPage = observer((props: Props) => {
               <IconButton
                 edge={'start'}
                 onClick={() => {
-                  copy(address);
+                  copy(accountAddress);
                   setCopyStatus(true);
                 }}
               >
                 <FilterNoneIcon />
               </IconButton>
               <ListItemText
-                primary={'Address: ' + address}
+                primary={'Account Address: ' + accountAddress}
                 style={{ overflowWrap: 'break-word' }}
               />
             </ListItem>


### PR DESCRIPTION
Previously address was displaying Public Key Hex ( algo prefix + base16 Public Key).
It now displays the Ed25519 hash of the Public Key encoded in base64 for readability.
The Ed25519 hash is the blake2b hash of the bytes of 'ed25519' prefixed to the bytes of the Public Key - this is now termed the Account Address in the Signer UI.