### PR TITLE
Adds cspr.live to domain list for MAKE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "0.3.6",
+  "version": "0.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -31023,9 +31023,9 @@
       }
     },
     "node_modules/webpack/node_modules/ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "dependencies": {
         "figgy-pudding": "^3.5.1"
       }
@@ -56150,9 +56150,9 @@
           }
         },
         "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -22,7 +22,9 @@
       "matches": [
         "*://*.casperlabs.io/*", 
         "*://localhost/*",
-        "*://*.make.services/*"
+        "*://*.make.services/*",
+        "*://cspr.live/*",
+        "*://*.cspr.live/*"
       ],
       "js": ["./scripts/content/content.js"],
       "run_at": "document_start",


### PR DESCRIPTION
As the title says, adds the cspr.live domain to the extensions manifest. This means the content script will be injected into the page from the Signer.