### PR TITLE
Hotfix: Adds getActivePublicKey() method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "0.3.6",
+  "version": "0.3.7",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",

--- a/src/content/inpage.ts
+++ b/src/content/inpage.ts
@@ -26,6 +26,10 @@ class CasperLabsPluginHelper {
   async getSelectedPublicKeyBase64() {
     return this.call<string>('getSelectedPublicKeyBase64');
   }
+
+  async getActivePublicKey() {
+    return this.call<string>('getActivePublicKey');
+  }
 }
 
 // inject to window, so that Clarity code could use it.

--- a/src/lib/rpc/Provider.ts
+++ b/src/lib/rpc/Provider.ts
@@ -53,6 +53,10 @@ export function setupInjectPageAPIServer(
     signMessageManager.getSelectedPublicKeyBase64.bind(signMessageManager)
   );
   rpc.register(
+    'getActivePublicKey',
+    signMessageManager.getActivePublicKey.bind(signMessageManager)
+  );
+  rpc.register(
     'isConnected',
     connectionManager.isConnected.bind(connectionManager)
   );


### PR DESCRIPTION
The new method is in addition to all existing methods.
It returns the hex-encoded public key with the algorithm prefix.
Version is bumped to 0.3.7 for release.

Will need a counterpart PR in the casper-client-sdk