### PR TITLE
Hotfix/expose disconnect method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "0.3.7",
+  "version": "0.3.8",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",

--- a/src/content/inpage.ts
+++ b/src/content/inpage.ts
@@ -19,6 +19,10 @@ class CasperLabsPluginHelper {
     return this.call<void>('requestConnection');
   }
 
+  async disconnectFromSite() {
+    return this.call<void>('disconnectFromSite');
+  }
+
   async sign(message: string, publicKeyBase64?: string) {
     return this.call<string>('sign', message, publicKeyBase64);
   }

--- a/src/lib/rpc/Provider.ts
+++ b/src/lib/rpc/Provider.ts
@@ -68,4 +68,8 @@ export function setupInjectPageAPIServer(
     'connectToSite',
     connectionManager.connectToSite.bind(connectionManager)
   );
+  rpc.register(
+    'disconnectFromSite',
+    connectionManager.disconnectFromSite.bind(connectionManager)
+  );
 }


### PR DESCRIPTION
As per issue #48 this exposes the `disconnectFromSite()` method to client sites so they can have a 'log out' functionality on _cspr.live_