### PR TITLE
Hotfix/correct representation of keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "0.3.8",
+  "version": "0.3.9",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -34,7 +34,7 @@ import Dialog from '@material-ui/core/Dialog';
 import { confirm } from './Confirmation';
 import copy from 'copy-to-clipboard';
 import Pages from './Pages';
-import { decodeBase64, encodeBase16, Keys } from 'casper-client-sdk';
+import { decodeBase64, encodeBase16, Keys, PublicKey } from 'casper-client-sdk';
 
 // interface Item {
 //   id: string;
@@ -69,12 +69,12 @@ export const AccountManagementPage = observer((props: Props) => {
   const [copyStatus, setCopyStatus] = React.useState(false);
   const [publicKey64, setPublicKey64] = React.useState('');
 
-  // Whilst the prefix is currently hard-coded to 01 (ed25519) this
-  // will soon be dynamic to support secp256k1 keys.
-  const publicKey = '01' + encodeBase16(decodeBase64(publicKey64));
-  const accountHash = encodeBase16(
-    Keys.Ed25519.accountHash(decodeBase64(publicKey64))
+  // Currently only supports ED25519 keys will soon be extended to support SECP256k1 keys.
+  const publicKey = PublicKey.from(
+    decodeBase64(publicKey64),
+    Keys.SignatureAlgorithm.Ed25519
   );
+  const accountHash = encodeBase16(publicKey.toAccountHash());
 
   const handleClickOpen = (account: SignKeyPairWithAlias) => {
     setOpenDialog(true);
@@ -270,14 +270,14 @@ export const AccountManagementPage = observer((props: Props) => {
               <IconButton
                 edge={'start'}
                 onClick={() => {
-                  copy(publicKey);
+                  copy(publicKey.toAccountHex());
                   setCopyStatus(true);
                 }}
               >
                 <FilterNoneIcon />
               </IconButton>
               <ListItemText
-                primary={'Public Key: ' + publicKey}
+                primary={'Public Key: ' + publicKey.toAccountHex()}
                 style={{ overflowWrap: 'break-word' }}
               />
             </ListItem>

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -107,6 +107,7 @@ export const AccountManagementPage = observer((props: Props) => {
   const handleUpdateName = () => {
     if (selectedAccount) {
       props.authContainer.renameUserAccount(selectedAccount.name, name);
+      props.authContainer.switchToAccount(name);
       handleClose();
     }
   };


### PR DESCRIPTION
## Signer Hotfix v0.3.9
Changes:
- Represents Public Key as hex-encoded public key prefixed with the algorithm byte.
- Represents the Account Hash as the hex-encoded account hash of the public key.
![New-Account-View](https://user-images.githubusercontent.com/69711689/116722172-fea0a080-a9d5-11eb-9462-c027352e2cf7.png)

Currently only supporting ED25519 keys to be extended in the next release.