### PR TITLE
Adds getVersion() method

### DIFF
--- a/src/background/ConnectionManager.ts
+++ b/src/background/ConnectionManager.ts
@@ -119,6 +119,10 @@ export default class ConnectionManager {
     this.store.set({ connectedSites: this.appState.connectedSites.toJS() });
   }
 
+  public getVersion() {
+    return chrome.runtime.getManifest().version;
+  }
+
   private getActiveTab(): Promise<string | null> {
     return new Promise((resolve, reject) => {
       chrome.tabs.query({ active: true, lastFocusedWindow: true }, tabs => {

--- a/src/content/inpage.ts
+++ b/src/content/inpage.ts
@@ -34,6 +34,10 @@ class CasperLabsPluginHelper {
   async getActivePublicKey() {
     return this.call<string>('getActivePublicKey');
   }
+
+  async getVersion() {
+    return this.call<string>('getVersion');
+  }
 }
 
 // inject to window, so that Clarity code could use it.

--- a/src/lib/rpc/Provider.ts
+++ b/src/lib/rpc/Provider.ts
@@ -69,4 +69,8 @@ export function setupInjectPageAPIServer(
     'removeSite',
     connectionManager.removeSite.bind(connectionManager)
   );
+  rpc.register(
+    'getVersion',
+    connectionManager.getVersion.bind(connectionManager)
+  );
 }


### PR DESCRIPTION
Adds method for retrieving the current version of the Signer extension.
Allows clients to enforce a min. version to avoid incompatibilities.