### PR TITLE
Re-introduce Importing Accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2275,6 +2275,11 @@
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^13.0.0"
       }
+    },
+    "@lapo/asn1js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lapo/asn1js/-/asn1js-1.2.1.tgz",
+      "integrity": "sha512-Nunnx2ey7p5KzcwLvi3WBGjkrVnTQb0/jfH1KBS/z7V5ta+1JanJ8Emo5d5+dcmIMKDSLDNa8T7nYTr1Ss0GeA=="
     },
     "@material-ui/core": {
       "version": "4.11.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "dependencies": {
     "@extend-chrome/storage": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.14.3",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "1.0.2",
   "private": true,
   "dependencies": {
-    "@extend-chrome/storage": "^1.4.3",
     "@babel/core": "^7.14.3",
+    "@extend-chrome/storage": "^1.4.3",
     "@fortawesome/fontawesome-free": "^5.13.0",
+    "@lapo/asn1js": "^1.2.1",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.0.2",
+  "version": "1.1.0",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",

--- a/src/@types/asn1js.d.ts
+++ b/src/@types/asn1js.d.ts
@@ -1,0 +1,3 @@
+declare module '@lapo/asn1js';
+declare module '@lapo/asn1js/base64';
+declare module '@lapo/asn1js/hex';

--- a/src/background/AuthController.ts
+++ b/src/background/AuthController.ts
@@ -144,8 +144,6 @@ class AuthController {
     }
     const secretKeyBytes = decodeBase64(secretKeyBase64);
     let secretKey, publicKey, keyPair: Keys.Ed25519 | Keys.Secp256K1;
-    console.log('AAA', algorithm);
-
     switch (algorithm) {
       case 'ed25519': {
         secretKey = Keys.Ed25519.parsePrivateKey(secretKeyBytes);

--- a/src/background/SignMessageManager.ts
+++ b/src/background/SignMessageManager.ts
@@ -226,11 +226,6 @@ export default class SignMessageManager extends events.EventEmitter {
       deployData.signingKey &&
       activeKeyPair.publicKey.toAccountHex() !== deployData.signingKey
     ) {
-      console.log(
-        '!',
-        activeKeyPair.publicKey.toAccountHex(),
-        deployData.signingKey
-      );
       deployData.status = 'failed';
       deployData.error = new Error('Active key changed during signing');
       this.saveAndEmitEventIfNeeded(deployData);

--- a/src/background/SignMessageManager.ts
+++ b/src/background/SignMessageManager.ts
@@ -151,6 +151,17 @@ export default class SignMessageManager extends events.EventEmitter {
     publicKey: string // hex-encoded PublicKey bytes with algo prefix
   ): Promise<any> {
     return new Promise((resolve, reject) => {
+      // TODO: Need to abstract it to reusable method
+      const { currentTab, connectedSites } = this.appState;
+      const connected =
+        currentTab &&
+        connectedSites.some(
+          site => site.url === currentTab.url && site.isConnected
+        );
+      if (!connected) {
+        return reject('This site is not connected');
+      }
+
       // Adding the deploy to the queue will update the extension state and UI
       const deployId = this.addUnsignedDeployToQueue(deploy, publicKey);
       this.popupManager.openPopup('sign');

--- a/src/background/SignMessageManager.ts
+++ b/src/background/SignMessageManager.ts
@@ -226,6 +226,11 @@ export default class SignMessageManager extends events.EventEmitter {
       deployData.signingKey &&
       activeKeyPair.publicKey.toAccountHex() !== deployData.signingKey
     ) {
+      console.log(
+        '!',
+        activeKeyPair.publicKey.toAccountHex(),
+        deployData.signingKey
+      );
       deployData.status = 'failed';
       deployData.error = new Error('Active key changed during signing');
       this.saveAndEmitEventIfNeeded(deployData);

--- a/src/lapo.d.ts
+++ b/src/lapo.d.ts
@@ -1,0 +1,3 @@
+declare module '@lapo/asn1js';
+declare module '@lapo/asn1js/hex';
+declare module '@lapo/asn1js/base64';

--- a/src/popup/BackgroundManager.ts
+++ b/src/popup/BackgroundManager.ts
@@ -27,7 +27,6 @@ export class BackgroundManager {
 
   @action.bound
   private onStateUpdate(appState: AppState) {
-    console.log(appState);
     this.appState.isUnlocked = appState.isUnlocked;
     this.appState.currentTab = appState.currentTab;
     this.appState.connectionRequested = appState.connectionRequested;

--- a/src/popup/components/AccountPage.tsx
+++ b/src/popup/components/AccountPage.tsx
@@ -136,13 +136,22 @@ class AccountPage extends React.Component<Props, State> {
     await this.props.authContainer.importUserAccount(
       this.accountForm.name.$,
       this.accountForm.secretKeyBase64.value,
-      this.accountForm.algorithmType!
+      this.accountForm.algorithm.$
     );
     this.props.history.push(Pages.Home);
     this.props.history.replace(Pages.Home);
   }
 
   renderImportForm() {
+    const showAlgoHelp = (event: React.MouseEvent<HTMLButtonElement>) => {
+      this.setState({ algoAnchorEl: event.currentTarget });
+    };
+    const helpOpen = Boolean(showAlgoHelp);
+    const helpId = helpOpen ? 'algo-helper' : undefined;
+    const helpClose = () => {
+      this.setState({ algoAnchorEl: null });
+    };
+
     const form = this.accountForm as ImportAccountFormData;
     return (
       <form className={this.props.classes.root}>
@@ -236,7 +245,11 @@ class AccountPage extends React.Component<Props, State> {
             <Box ml={1}>
               <Typography component={'span'}>
                 <Box fontSize={12}>
-                  {form.file ? form.file.name : 'No file selected'}
+                  {form.file
+                    ? form.file.name
+                    : form.algorithm.$
+                    ? 'No file selected'
+                    : 'Please select algorithm first'}
                 </Box>
               </Typography>
             </Box>

--- a/src/popup/components/AccountPage.tsx
+++ b/src/popup/components/AccountPage.tsx
@@ -11,12 +11,12 @@ import {
 import ErrorContainer from '../container/ErrorContainer';
 import {
   Button,
-  Checkbox,
+  // Checkbox,
   createStyles,
   Theme,
   Typography,
   WithStyles,
-  FormControlLabel,
+  // FormControlLabel,
   FormControl,
   Box,
   InputLabel,
@@ -48,11 +48,13 @@ interface Props extends RouteComponentProps, WithStyles<typeof styles> {
   action: 'Import' | 'Create';
 }
 
+interface State {
+  keyDownloadEnabled: boolean;
+  algoAnchorEl: HTMLButtonElement | null;
+}
+
 @observer
-class AccountPage extends React.Component<
-  Props,
-  { keyDownloadEnabled: boolean; algoAnchorEl: HTMLButtonElement | null }
-> {
+class AccountPage extends React.Component<Props, State> {
   @observable accountForm: ImportAccountFormData | CreateAccountFormData;
 
   private popupManager: PopupManager;
@@ -153,46 +155,17 @@ class AccountPage extends React.Component<
     const form = this.accountForm as ImportAccountFormData;
     return (
       <form className={this.props.classes.root}>
-        <FormControl>
-          <Typography id="continuous-slider" variant="h6" gutterBottom>
-            Import from Secret Key File
-          </Typography>
-          <Box
-            display={'flex'}
-            flexDirection={'row'}
-            alignItems={'center'}
-            m={1}
-          >
-            <Button
-              id={'private-key-uploader'}
-              variant="contained"
-              style={{
-                backgroundColor: 'var(--cspr-dark-blue)',
-                color: 'white'
-              }}
-              component="label"
-            >
-              Upload
-              <input
-                type="file"
-                style={{ display: 'none' }}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  form.handleFileSelect(e)
-                }
-              />
-            </Button>
-            <Box ml={1}>
-              <Typography component={'span'}>
-                <Box fontSize={12}>
-                  {form.file ? form.file.name : 'No file selected'}
-                </Box>
-              </Typography>
-            </Box>
-          </Box>
-        </FormControl>
+        <Typography id="continuous-slider" variant="h6" gutterBottom>
+          Import from Secret Key File
+        </Typography>
         <Box>
-          <FormControl style={{ width: '80%' }}>
-            <InputLabel id="algo-select-lbl">Algorithm</InputLabel>
+          <FormControl
+            style={{
+              width: '80%',
+              marginBottom: '1rem'
+            }}
+          >
+            <InputLabel id="algo-select-lbl">Select algorithm</InputLabel>
             <SelectFieldWithFormState
               fullWidth
               labelId="algo-select-lbl"
@@ -243,9 +216,48 @@ class AccountPage extends React.Component<
             </Popover>
           )}
         </Box>
+        <FormControl>
+          <Box
+            display={'flex'}
+            flexDirection={'row'}
+            alignItems={'center'}
+            m={1}
+          >
+            <Button
+              id={'private-key-uploader'}
+              variant="contained"
+              style={{
+                backgroundColor: 'var(--cspr-dark-blue)',
+                color: 'white'
+              }}
+              component="label"
+            >
+              Upload
+              <input
+                disabled={!form.algorithm.$}
+                type="file"
+                style={{ display: 'none' }}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  form.handleFileSelect(e)
+                }
+              />
+            </Button>
+            <Box ml={1}>
+              <Typography component={'span'}>
+                <Box fontSize={12}>
+                  {form.file
+                    ? form.file.name
+                    : form.algorithm.$
+                    ? 'No file selected'
+                    : 'Please select algorithm first'}
+                </Box>
+              </Typography>
+            </Box>
+          </Box>
+        </FormControl>
         <TextFieldWithFormState
           fullWidth
-          label="Name"
+          label="Name imported account"
           placeholder="Human Readable Alias"
           id="import-name"
           fieldState={this.accountForm.name}

--- a/src/popup/components/AccountPage.tsx
+++ b/src/popup/components/AccountPage.tsx
@@ -136,22 +136,13 @@ class AccountPage extends React.Component<Props, State> {
     await this.props.authContainer.importUserAccount(
       this.accountForm.name.$,
       this.accountForm.secretKeyBase64.value,
-      this.accountForm.algorithm.$
+      this.accountForm.algorithmType!
     );
     this.props.history.push(Pages.Home);
     this.props.history.replace(Pages.Home);
   }
 
   renderImportForm() {
-    const showAlgoHelp = (event: React.MouseEvent<HTMLButtonElement>) => {
-      this.setState({ algoAnchorEl: event.currentTarget });
-    };
-    const helpOpen = Boolean(showAlgoHelp);
-    const helpId = helpOpen ? 'algo-helper' : undefined;
-    const helpClose = () => {
-      this.setState({ algoAnchorEl: null });
-    };
-
     const form = this.accountForm as ImportAccountFormData;
     return (
       <form className={this.props.classes.root}>

--- a/src/popup/components/AccountPage.tsx
+++ b/src/popup/components/AccountPage.tsx
@@ -158,7 +158,7 @@ class AccountPage extends React.Component<Props, State> {
         <Typography id="continuous-slider" variant="h6" gutterBottom>
           Import from Secret Key File
         </Typography>
-        <Box>
+        {/* <Box>
           <FormControl
             style={{
               width: '80%',
@@ -215,7 +215,7 @@ class AccountPage extends React.Component<Props, State> {
               </Typography>
             </Popover>
           )}
-        </Box>
+        </Box> */}
         <FormControl>
           <Box
             display={'flex'}
@@ -234,7 +234,7 @@ class AccountPage extends React.Component<Props, State> {
             >
               Upload
               <input
-                disabled={!form.algorithm.$}
+                // disabled={!form.algorithm.$}
                 type="file"
                 style={{ display: 'none' }}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
@@ -245,11 +245,7 @@ class AccountPage extends React.Component<Props, State> {
             <Box ml={1}>
               <Typography component={'span'}>
                 <Box fontSize={12}>
-                  {form.file
-                    ? form.file.name
-                    : form.algorithm.$
-                    ? 'No file selected'
-                    : 'Please select algorithm first'}
+                  {form.file ? form.file.name : 'No file selected'}
                 </Box>
               </Typography>
             </Box>

--- a/src/popup/components/AccountPage.tsx
+++ b/src/popup/components/AccountPage.tsx
@@ -11,12 +11,12 @@ import {
 import ErrorContainer from '../container/ErrorContainer';
 import {
   Button,
-  // Checkbox,
+  Checkbox,
   createStyles,
   Theme,
   Typography,
   WithStyles,
-  // FormControlLabel,
+  FormControlLabel,
   FormControl,
   Box,
   InputLabel,
@@ -177,10 +177,7 @@ class AccountPage extends React.Component<
                 type="file"
                 style={{ display: 'none' }}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  // form.handleFileSelect(e)
-                  {
-                    return;
-                  }
+                  form.handleFileSelect(e)
                 }
               />
             </Button>
@@ -292,10 +289,6 @@ class AccountPage extends React.Component<
           id="import-name"
           fieldState={this.accountForm.name}
         />
-        {/* 
-          TODO: Uncomment the below FormControl and delete the subsequent
-          TextFieldWithFormState when SECP256k1 generation is fixed
-        */}
         <FormControl fullWidth>
           <InputLabel id="algo-select-lbl">Algorithm</InputLabel>
           <SelectFieldWithFormState

--- a/src/popup/components/AccountPage.tsx
+++ b/src/popup/components/AccountPage.tsx
@@ -11,19 +11,14 @@ import {
 import ErrorContainer from '../container/ErrorContainer';
 import {
   Button,
-  // Checkbox,
   createStyles,
   Theme,
   Typography,
   WithStyles,
-  // FormControlLabel,
   FormControl,
   Box,
-  InputLabel,
-  Popover,
-  IconButton
+  InputLabel
 } from '@material-ui/core';
-import HelpIcon from '@material-ui/icons/Help';
 import { SelectFieldWithFormState, TextFieldWithFormState } from './Forms';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { decodeBase16, decodeBase64, Keys } from 'casper-client-sdk';
@@ -143,14 +138,14 @@ class AccountPage extends React.Component<Props, State> {
   }
 
   renderImportForm() {
-    const showAlgoHelp = (event: React.MouseEvent<HTMLButtonElement>) => {
-      this.setState({ algoAnchorEl: event.currentTarget });
-    };
-    const helpOpen = Boolean(showAlgoHelp);
-    const helpId = helpOpen ? 'algo-helper' : undefined;
-    const helpClose = () => {
-      this.setState({ algoAnchorEl: null });
-    };
+    // const showAlgoHelp = (event: React.MouseEvent<HTMLButtonElement>) => {
+    //   this.setState({ algoAnchorEl: event.currentTarget });
+    // };
+    // const helpOpen = Boolean(showAlgoHelp);
+    // const helpId = helpOpen ? 'algo-helper' : undefined;
+    // const helpClose = () => {
+    // this.setState({ algoAnchorEl: null });
+    // };
 
     const form = this.accountForm as ImportAccountFormData;
     return (
@@ -245,11 +240,7 @@ class AccountPage extends React.Component<Props, State> {
             <Box ml={1}>
               <Typography component={'span'}>
                 <Box fontSize={12}>
-                  {form.file
-                    ? form.file.name
-                    : form.algorithm.$
-                    ? 'No file selected'
-                    : 'Please select algorithm first'}
+                  {form.file ? form.file.name : 'No file selected'}
                 </Box>
               </Typography>
             </Box>

--- a/src/popup/components/Home.tsx
+++ b/src/popup/components/Home.tsx
@@ -167,7 +167,7 @@ class Home extends React.Component<Props, {}> {
           )}
 
           <Grid item>
-            {/* <FormControl fullWidth className={this.props.classes.margin}>
+            <FormControl fullWidth className={this.props.classes.margin}>
               <Button
                 aria-label="This will open a new window to import a key to your vault"
                 component={Link}
@@ -184,8 +184,7 @@ class Home extends React.Component<Props, {}> {
               >
                 Import Account
               </Button>
-            </FormControl> */}
-
+            </FormControl>
             <FormControl fullWidth className={this.props.classes.margin}>
               <Button
                 aria-label="This will open a form to create an account - focus will be given to the input field for key name"

--- a/src/popup/container/ImportAccountContainer.ts
+++ b/src/popup/container/ImportAccountContainer.ts
@@ -8,8 +8,9 @@ import { action, computed, observable } from 'mobx';
 import { encodeBase64 } from 'tweetnacl-util';
 import ErrorContainer from './ErrorContainer';
 import { Keys } from 'casper-client-sdk';
-// import KeyEncoder from 'key-encoder';
-// import ec from 'elliptic';
+import KeyEncoder from 'key-encoder';
+import ec from 'elliptic';
+import keyEncoder from 'key-encoder';
 export interface SubmittableFormData {
   submitDisabled: boolean;
   resetFields: () => void;
@@ -28,62 +29,56 @@ export class ImportAccountFormData implements SubmittableFormData {
   );
   @observable file: File | null = null;
 
-  // private checkFileContent(fileContent: string) {
-  //   if (!fileContent) {
-  //     return 'The content of imported file cannot be empty!';
-  //   }
-  //   if (fileContent.includes('PUBLIC KEY')) {
-  //     return 'Not a secret key file!';
-  //   }
-  //   return null;
-  // }
+  private checkFileContent(fileContent: string) {
+    if (!fileContent) {
+      return 'The content of imported file cannot be empty!';
+    }
+    if (fileContent.includes('PUBLIC KEY')) {
+      return 'Not a secret key file!';
+    }
+    return null;
+  }
 
   constructor(private errors: ErrorContainer) {}
 
-  //   handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //     if (this.errors.lastError) {
-  //       this.errors.dismissLast();
-  //     }
-  //     if (e.target.files) {
-  //       this.file = e.target.files[0];
-  //       const reader = new FileReader();
-  //       reader.readAsText(this.file);
-  //       reader.onload = e => {
-  //         const fileContents = reader.result as string;
-  //         const errorMsg = this.checkFileContent(fileContents);
-  //         if (errorMsg === null) {
-  //           const file = this.file?.name!.split('.');
-  //           if (file === undefined) {
-  //             this.errors.capture(Promise.reject(new Error('File undefined')));
-  //           } else {
-  //             // File is not undefined now check format by extension
-  //             const fileExt = file[1];
-  //             if (fileExt !== 'pem') {
-  //               this.errors.capture(
-  //                 Promise.reject(
-  //                   new Error(
-  //                     `Invalid file format: .${fileExt}. Please upload a .pem file.`
-  //                   )
-  //                 )
-  //               );
-  //             } else {
-  //               // Move decodeFromPEM to background by passing fileContents
-  //               const encoder = new KeyEncoder({
-  //                 curve: new ec('secp256k1'),
-  //                 privatePEMOptions: { label: 'PRIVATE KEY' },
-  //                 publicPEMOptions: { label: 'PUBLIC KEY' },
-  //                 curveParameters: undefined
-  //               });
-  //               let decoded = encoder.encodePrivate(fileContents, 'pem', 'raw');
-  //               this.secretKeyBase64.onChange(decoded);
-  //             }
-  //           }
-  //         } else {
-  //           this.errors.capture(Promise.reject(new Error(errorMsg)));
-  //         }
-  //       };
-  //     }
-  //   };
+  handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (this.errors.lastError) {
+      this.errors.dismissLast();
+    }
+    if (e.target.files) {
+      this.file = e.target.files[0];
+      const reader = new FileReader();
+      reader.readAsText(this.file);
+      reader.onload = e => {
+        const fileContents = reader.result as string;
+        const errorMsg = this.checkFileContent(fileContents);
+        if (errorMsg === null) {
+          const file = this.file?.name!.split('.');
+          if (file === undefined) {
+            this.errors.capture(Promise.reject(new Error('File undefined')));
+          } else {
+            // File is not undefined now check format by extension
+            const fileExt = file[1];
+            if (fileExt !== 'pem') {
+              this.errors.capture(
+                Promise.reject(
+                  new Error(
+                    `Invalid file format: .${fileExt}. Please upload a .pem file.`
+                  )
+                )
+              );
+            } else {
+              console.log(fileContents);
+              keyEncoder = new KeyEncoder('secp256k1');
+              // this.secretKeyBase64.onChange('noKey');
+            }
+          }
+        } else {
+          this.errors.capture(Promise.reject(new Error(errorMsg)));
+        }
+      };
+    }
+  };
 
   @computed
   get submitDisabled(): boolean {

--- a/src/popup/container/ImportAccountContainer.ts
+++ b/src/popup/container/ImportAccountContainer.ts
@@ -66,22 +66,26 @@ export class ImportAccountFormData implements SubmittableFormData {
               );
             } else {
               let pem, parsedKey;
-              switch (this.algorithm.$) {
-                case 'ed25519': {
-                  pem = Keys.Ed25519.readBase64WithPEM(fileContents);
-                  parsedKey = Keys.Ed25519.parsePrivateKey(pem);
-                  break;
+              try {
+                switch (this.algorithm.$) {
+                  case 'ed25519': {
+                    pem = Keys.Ed25519.readBase64WithPEM(fileContents);
+                    parsedKey = Keys.Ed25519.parsePrivateKey(pem);
+                    break;
+                  }
+                  case 'secp256k1': {
+                    pem = Keys.Secp256K1.readBase64WithPEM(fileContents);
+                    parsedKey = Keys.Secp256K1.parsePrivateKey(pem);
+                    break;
+                  }
+                  default: {
+                    throw new Error('Invalid algorithm selected');
+                  }
                 }
-                case 'secp256k1': {
-                  pem = Keys.Secp256K1.readBase64WithPEM(fileContents);
-                  parsedKey = Keys.Secp256K1.parsePrivateKey(pem);
-                  break;
-                }
-                default: {
-                  throw new Error('Invalid algorithm selected');
-                }
+                this.secretKeyBase64.onChange(encodeBase64(parsedKey));
+              } catch (e) {
+                console.log('ERROR', e);
               }
-              this.secretKeyBase64.onChange(encodeBase64(parsedKey));
             }
           }
         } else {

--- a/src/popup/container/ImportAccountContainer.ts
+++ b/src/popup/container/ImportAccountContainer.ts
@@ -16,8 +16,6 @@ export interface SubmittableFormData {
   resetFields: () => void;
 }
 
-type Algorithms = 'ed25519' | 'secp256k1';
-
 export class ImportAccountFormData implements SubmittableFormData {
   secretKeyBase64: FieldState<string> = new FieldState<string>('').validators(
     valueRequired
@@ -26,8 +24,6 @@ export class ImportAccountFormData implements SubmittableFormData {
     valueRequired,
     isAlgorithm
   );
-  algorithmType: Algorithms | undefined = undefined;
-
   name: FieldState<string> = new FieldState<string>('').validators(
     valueRequired
   );
@@ -137,14 +133,16 @@ export class ImportAccountFormData implements SubmittableFormData {
   @computed
   get submitDisabled(): boolean {
     return !(
-      fieldSubmittable(this.secretKeyBase64) && fieldSubmittable(this.name)
+      fieldSubmittable(this.secretKeyBase64) &&
+      fieldSubmittable(this.name) &&
+      fieldSubmittable(this.algorithm)
     );
   }
 
   @action
   resetFields() {
     this.secretKeyBase64.reset();
-    this.algorithmType = undefined;
+    this.algorithm.reset();
     this.name.reset();
   }
 }

--- a/src/popup/container/ImportAccountContainer.ts
+++ b/src/popup/container/ImportAccountContainer.ts
@@ -16,6 +16,8 @@ export interface SubmittableFormData {
   resetFields: () => void;
 }
 
+type Algorithms = 'ed25519' | 'secp256k1';
+
 export class ImportAccountFormData implements SubmittableFormData {
   secretKeyBase64: FieldState<string> = new FieldState<string>('').validators(
     valueRequired
@@ -24,6 +26,8 @@ export class ImportAccountFormData implements SubmittableFormData {
     valueRequired,
     isAlgorithm
   );
+  algorithmType: Algorithms | undefined = undefined;
+
   name: FieldState<string> = new FieldState<string>('').validators(
     valueRequired
   );
@@ -33,7 +37,7 @@ export class ImportAccountFormData implements SubmittableFormData {
   private parseAlgorithm(val: any) {
     let decoded;
     try {
-      var der: Uint8Array = this.reHex.test(val)
+      const der: Uint8Array = this.reHex.test(val)
         ? Hex.decode(val)
         : Base64.unarmor(val);
       decoded = ASN1.decode(der);
@@ -133,16 +137,14 @@ export class ImportAccountFormData implements SubmittableFormData {
   @computed
   get submitDisabled(): boolean {
     return !(
-      fieldSubmittable(this.secretKeyBase64) &&
-      fieldSubmittable(this.name) &&
-      fieldSubmittable(this.algorithm)
+      fieldSubmittable(this.secretKeyBase64) && fieldSubmittable(this.name)
     );
   }
 
   @action
   resetFields() {
     this.secretKeyBase64.reset();
-    this.algorithm.reset();
+    this.algorithmType = undefined;
     this.name.reset();
   }
 }

--- a/src/popup/container/ImportAccountContainer.ts
+++ b/src/popup/container/ImportAccountContainer.ts
@@ -65,10 +65,10 @@ export class ImportAccountFormData implements SubmittableFormData {
           this.secretKeyBase64.onChange(encodeBase64(decodeBase16(hexKey)));
         }
       } catch (err) {
-        console.log(err);
+        this.errors.capture(Promise.reject(err));
       }
     } catch (e) {
-      console.error(e);
+      this.errors.capture(Promise.reject(e));
     }
   }
 

--- a/src/popup/container/ImportAccountContainer.ts
+++ b/src/popup/container/ImportAccountContainer.ts
@@ -10,7 +10,6 @@ import ErrorContainer from './ErrorContainer';
 import { Keys } from 'casper-client-sdk';
 import KeyEncoder from 'key-encoder';
 import ec from 'elliptic';
-import keyEncoder from 'key-encoder';
 export interface SubmittableFormData {
   submitDisabled: boolean;
   resetFields: () => void;
@@ -50,6 +49,7 @@ export class ImportAccountFormData implements SubmittableFormData {
       const reader = new FileReader();
       reader.readAsText(this.file);
       reader.onload = e => {
+        console.log("E", e);
         const fileContents = reader.result as string;
         const errorMsg = this.checkFileContent(fileContents);
         if (errorMsg === null) {
@@ -69,7 +69,13 @@ export class ImportAccountFormData implements SubmittableFormData {
               );
             } else {
               console.log(fileContents);
-              keyEncoder = new KeyEncoder('secp256k1');
+
+              // There should be if with algorithm
+              const pem = Keys.Secp256K1.readBase64WithPEM(fileContents);
+              const myKey = Keys.Secp256K1.parsePrivateKey(pem);
+              console.log('myKey', myKey, this.algorithm);
+              // const myKey = Keys.Ed25519.readBase64WithPEM(fileContents);
+              // keyEncoder = new KeyEncoder('secp256k1');
               // this.secretKeyBase64.onChange('noKey');
             }
           }

--- a/src/popup/container/ImportAccountContainer.ts
+++ b/src/popup/container/ImportAccountContainer.ts
@@ -56,13 +56,13 @@ export class ImportAccountFormData implements SubmittableFormData {
           );
         }
         if (algorithmCheck === 'curveEd25519') {
-          this.algorithm.$ = 'ed25519';
+          this.algorithm.onChange('ed25519');
           let hexKey = decoded.toPrettyString().split('\n')[4].split('|')[1];
-          this.secretKeyBase64.$ = encodeBase64(decodeBase16(hexKey));
+          this.secretKeyBase64.onChange(encodeBase64(decodeBase16(hexKey)));
         } else {
-          this.algorithm.$ = algorithmCheck;
+          this.algorithm.onChange(algorithmCheck);
           let hexKey = decoded.toPrettyString().split('\n')[2].split('|')[1];
-          this.secretKeyBase64.$ = encodeBase64(decodeBase16(hexKey));
+          this.secretKeyBase64.onChange(encodeBase64(decodeBase16(hexKey)));
         }
       } catch (err) {
         console.log(err);
@@ -113,9 +113,6 @@ export class ImportAccountFormData implements SubmittableFormData {
             } else {
               try {
                 this.parseAlgorithm(fileContents);
-                console.log(
-                  `Algorithm: ${this.algorithm.$}\n Key: ${this.secretKeyBase64.$}`
-                );
               } catch (e) {
                 this.errors.capture(
                   Promise.reject(new Error('Failed to parse key'))


### PR DESCRIPTION
This PR re-implements the importing account functionality.
The import page has changed and now forces users to select which algorithm was used to generate the key to be imported. There is a help tooltip for users who are unsure of which to select which explains how to check via the `pub_key_hex` file