### PR TITLE
QSP-5 / QSP-6 Require Password before Account Actions

### DIFF
--- a/src/background/AuthController.ts
+++ b/src/background/AuthController.ts
@@ -491,6 +491,24 @@ class AuthController {
     return this.appState.isUnlocked;
   }
 
+  async confirmPassword(password: string) {
+    let encryptedVault = await this.getStoredValueWithKey(
+      this.encryptedVaultKey
+    );
+    if (!encryptedVault) {
+      throw new Error('There is no vault');
+    }
+    let storedSalt = await this.getStoredValueWithKey(this.saltKey);
+    let [, saltedPassword] = this.saltPassword(password, storedSalt);
+    let saltedPasswordHash = this.hash(saltedPassword);
+    try {
+      await passworder.decrypt(saltedPasswordHash, encryptedVault);
+      return true;
+    } catch (err) {
+      throw new Error(err);
+    }
+  }
+
   @action.bound
   async clearAccount() {
     this.appState.userAccounts.clear();

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -120,4 +120,8 @@ async function setupPopupAPIServer() {
     'connection.removeSite',
     connectionManager.removeSite.bind(connectionManager)
   );
+  rpc.register(
+    'account.confirmPassword',
+    accountController.confirmPassword.bind(accountController)
+  );
 }

--- a/src/popup/BackgroundManager.ts
+++ b/src/popup/BackgroundManager.ts
@@ -158,4 +158,10 @@ export class BackgroundManager {
       this.rpc.call<void>('connection.resetConnectionRequest')
     );
   }
+
+  public confirmPassword(password: string) {
+    return this.errors.withCapture(
+      this.rpc.call<boolean>('account.confirmPassword', password)
+    );
+  }
 }

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -31,7 +31,7 @@ import AccountManager from '../container/AccountManager';
 import ConnectSignerContainer from '../container/ConnectSignerContainer';
 import { observer, Observer } from 'mobx-react';
 import Dialog from '@material-ui/core/Dialog';
-import { confirm } from './Confirmation';
+import { confirmWithPassword } from './Confirmation';
 import copy from 'copy-to-clipboard';
 import { KeyPairWithAlias } from '../../@types/models';
 import { PublicKey } from 'casper-client-sdk';
@@ -139,9 +139,11 @@ class AccountManagementPage extends React.Component<Props, State> {
   };
 
   handleClickRemove = (name: string) => {
-    confirm(
+    confirmWithPassword(
       <div className="text-danger">Remove account</div>,
-      'Are you sure you want to remove this account?'
+      <span>
+        Confirm password to remove account: <b>{name}</b>
+      </span>
     ).then(() => this.props.authContainer.removeUserAccount(name));
   };
 

--- a/src/popup/components/AccountPage.tsx
+++ b/src/popup/components/AccountPage.tsx
@@ -209,7 +209,7 @@ class AccountPage extends React.Component<Props, State> {
       <span>Confirm password to reveal key</span>
     ).then(() => {
       this.setState({ revealSecretKey: true });
-      setTimeout(() => this.setState({ revealSecretKey: false }), 3500);
+      setTimeout(() => this.setState({ revealSecretKey: false }), 5000);
     });
   };
 

--- a/src/popup/components/AccountPage.tsx
+++ b/src/popup/components/AccountPage.tsx
@@ -203,6 +203,7 @@ class AccountPage extends React.Component<Props, State> {
   }
 
   revealSecretKey = () => {
+    if (this.state.revealSecretKey) return;
     confirmWithPassword(
       <div className="text-danger">Reveal Key</div>,
       <span>Confirm password to reveal key</span>

--- a/src/popup/components/AccountPage.tsx
+++ b/src/popup/components/AccountPage.tsx
@@ -153,64 +153,6 @@ class AccountPage extends React.Component<Props, State> {
         <Typography id="continuous-slider" variant="h6" gutterBottom>
           Import from Secret Key File
         </Typography>
-        {/* <Box>
-          <FormControl
-            style={{
-              width: '80%',
-              marginBottom: '1rem'
-            }}
-          >
-            <InputLabel id="algo-select-lbl">Select algorithm</InputLabel>
-            <SelectFieldWithFormState
-              fullWidth
-              labelId="algo-select-lbl"
-              fieldState={this.accountForm.algorithm}
-              selectItems={[
-                { value: 'ed25519', text: 'ED25519' },
-                { value: 'secp256k1', text: 'SECP256k1' }
-              ]}
-            />
-          </FormControl>
-          <IconButton onClick={showAlgoHelp} style={{ float: 'right' }}>
-            <HelpIcon />
-          </IconButton>
-          {this.state.algoAnchorEl && (
-            <Popover
-              id={helpId}
-              open={helpOpen}
-              anchorEl={this.state.algoAnchorEl}
-              onClose={helpClose}
-              anchorOrigin={{
-                vertical: 'top',
-                horizontal: 'right'
-              }}
-              transformOrigin={{
-                vertical: 'bottom',
-                horizontal: 'right'
-              }}
-            >
-              <Typography
-                component={'summary'}
-                style={{
-                  padding: '1.4em',
-                  backgroundColor: 'var(--cspr-dark-blue)',
-                  color: 'white'
-                }}
-              >
-                <b>Which algorithm?</b>
-                <br />
-                Open your <code>public_key_hex</code> file which should be in
-                the same location as the secret key file.
-                <br />
-                If the key starts with:
-                <ul>
-                  <li>01: ED25519</li>
-                  <li>02: SECP256k1</li>
-                </ul>
-              </Typography>
-            </Popover>
-          )}
-        </Box> */}
         <FormControl>
           <Box
             display={'flex'}

--- a/src/popup/components/Confirmation.tsx
+++ b/src/popup/components/Confirmation.tsx
@@ -10,8 +10,14 @@ import {
   DialogActions,
   DialogContent,
   DialogContentText,
-  DialogTitle
+  DialogTitle,
+  FormControl
 } from '@material-ui/core';
+import { TextFieldWithFormState } from '../components/Forms';
+import AccountManager from '../container/AccountManager';
+import { ErrorContainer } from '../container/ErrorContainer';
+import { BackgroundManager } from '../BackgroundManager';
+import { AppState } from '../../lib/MemStore';
 
 interface Props extends ReactConfirmProps {
   proceedLabel: string;
@@ -65,6 +71,98 @@ export function confirm(
   options = {}
 ) {
   return createConfirmation(confirmable(Confirmation))({
+    title,
+    confirmation,
+    proceedLabel,
+    cancelLabel,
+    ...options
+  });
+}
+
+class ConfirmationWithPassword extends React.Component<Props, {}> {
+  private errors = new ErrorContainer();
+  private appState = new AppState();
+  private background = new BackgroundManager(this.appState, this.errors);
+  private accountManager = new AccountManager(
+    this.errors,
+    this.background,
+    this.appState
+  );
+  render() {
+    return (
+      <Dialog
+        open={this.props.show}
+        onClose={this.props.dismiss}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">{this.props.title}</DialogTitle>
+        <form>
+          <DialogContent>
+            <DialogContentText id="alert-dialog-description">
+              {this.props.confirmation}
+            </DialogContentText>
+            <FormControl>
+              <TextFieldWithFormState
+                autoFocus={true}
+                fieldState={
+                  this.accountManager.confirmPasswordForm.$.confirmPasswordField
+                }
+                required
+                label={'Password'}
+                type={'password'}
+              />
+            </FormControl>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={() => {
+                this.props.cancel();
+              }}
+              color="secondary"
+            >
+              {this.props.cancelLabel}
+            </Button>
+            <FormControl>
+              <Button
+                type="submit"
+                // TODO: This doesn't work - doesn't enable when field is non-null.
+                // disabled={this.accountManager.confirmPasswordDisabled}
+                onClick={async () => {
+                  let givenPassword =
+                    this.accountManager.confirmPasswordForm.$
+                      .confirmPasswordField.$;
+                  try {
+                    await this.accountManager.confirmPassword(givenPassword);
+                    this.accountManager.confirmPasswordForm.$.confirmPasswordField.reset();
+                    this.errors.dismissLast();
+                    this.props.proceed();
+                  } catch (e) {
+                    this.accountManager.confirmPasswordForm.$.confirmPasswordField.setError(
+                      e.message
+                    );
+                  }
+                }}
+                color="primary"
+              >
+                {this.props.proceedLabel}
+              </Button>
+            </FormControl>
+          </DialogActions>
+        </form>
+      </Dialog>
+    );
+  }
+}
+
+export function confirmWithPassword(
+  title: string | React.ReactElement,
+  confirmation: string | React.ReactElement,
+  proceedLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  options = {}
+) {
+  return createConfirmation(confirmable(ConfirmationWithPassword))({
     title,
     confirmation,
     proceedLabel,

--- a/src/popup/container/AccountManager.ts
+++ b/src/popup/container/AccountManager.ts
@@ -3,6 +3,8 @@ import { BackgroundManager } from '../BackgroundManager';
 import ErrorContainer from './ErrorContainer';
 import { AppState } from '../../lib/MemStore';
 import { KeyPairWithAlias } from '../../@types/models';
+import { FieldState, FormState } from 'formstate';
+import { valueRequired } from '../../lib/FormValidator';
 
 class AccountManager {
   constructor(
@@ -127,6 +129,24 @@ class AccountManager {
 
   async renameUserAccount(oldName: string, newName: string) {
     return this.backgroundManager.renameUserAccount(oldName, newName);
+  }
+
+  async confirmPassword(password: string) {
+    return this.backgroundManager.confirmPassword(password);
+  }
+
+  confirmPasswordForm = new FormState({
+    confirmPasswordField: new FieldState<string>('').validators(valueRequired)
+  });
+
+  @computed
+  get confirmPasswordDisabled(): boolean {
+    let disabled =
+      !this.confirmPasswordForm.$.confirmPasswordField.hasBeenValidated ||
+      (this.confirmPasswordForm.$.confirmPasswordField.hasBeenValidated &&
+        this.confirmPasswordForm.$.confirmPasswordField.hasError);
+    console.log(`Disabled: ${disabled}`);
+    return disabled;
   }
 }
 


### PR DESCRIPTION
This PR adds a password check before allowing a user to remove an account or view their secret key.

Files for testing:
[Signer-1.1.0-QSP5-6.zip](https://github.com/casper-ecosystem/signer/files/6605214/casperlabs_signer-1.1.0.zip)
