### PR TITLE
Add CasperHolders to authorized websites

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -24,7 +24,11 @@
         "*://localhost/*",
         "*://*.make.services/*",
         "*://cspr.live/*",
-        "*://*.cspr.live/*"
+        "*://*.cspr.live/*",
+        "*://casperholders.io/*",
+        "*://*.casperholders.io/*",
+        "*://casperholders.com/*",
+        "*://*.casperholders.com/*"
       ],
       "js": ["./scripts/content/content.js"],
       "run_at": "document_start",


### PR DESCRIPTION
This PR adds the two domains names for the casperholders application which interact with CasperSigner.

I have made a proposal to have a grant from DEVxDAO to publish the full code source of the application (https://portal.devxdao.com/app/proposal/72).

Currently, is closed source but if you guys want to review it I can add you to the repositories if needed.

The application will enable users to delegate / undelegate and see current balance between staked tokens and available tokens. (With more features to come for the validators).

I'm available on discord if needed to discuss about the application ! (Discord ID : killian#7405 )