### PR TITLE
QSP-10 Display Site URL on Connection Request

### DIFF
--- a/src/popup/components/ConnectSignerPage.tsx
+++ b/src/popup/components/ConnectSignerPage.tsx
@@ -26,10 +26,18 @@ class ConnectSignerPage extends React.Component<Props, {}> {
     if (!this.props.connectSignerContainer.connectionStatus) {
       return (
         <div style={{ flexGrow: 1 }}>
-          <Typography align={'center'} variant={'h5'}>
-            Connect Signer to site?
+          <Typography
+            align={'center'}
+            variant={'h5'}
+            style={{ marginBottom: '1rem' }}
+          >
+            Connection Request
           </Typography>
-
+          <Typography align={'center'} variant={'body1'}>
+            Would you like to allow{' '}
+            <b>{this.props.connectSignerContainer.currentTab?.url}</b> to
+            connect?
+          </Typography>
           <Box mt={8}>
             <Grid
               container


### PR DESCRIPTION
### Summary
When a site requests to connect the Signer now displays the URL for the site in the prompt so the user can be sure which tab is making the request.
This addresses Quantstamp issue QSP-10.

| Screenshots | Files to test |
| --- | ----------- |
| ![Connection-Prompt-with-Site](https://user-images.githubusercontent.com/69711689/122557639-f5769c00-d034-11eb-9bd0-9a0f3f6ecac6.png) | [Signer-1.2.0-QSP10](https://github.com/casper-ecosystem/signer/files/6676950/casperlabs_signer-1.2.0.zip) |
