### PR TITLE
Add casperholders domains to the manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -24,7 +24,11 @@
         "*://localhost/*",
         "*://*.make.services/*",
         "*://cspr.live/*",
-        "*://*.cspr.live/*"
+        "*://*.cspr.live/*",
+        "*://casperholders.io/*",
+        "*://*.casperholders.io/*",
+        "*://casperholders.com/*",
+        "*://*.casperholders.com/*"
       ],
       "js": ["./scripts/content/content.js"],
       "run_at": "document_start",


### PR DESCRIPTION
This PR adds the two domains names for the casperholders application which interact with CasperSigner.

I have made a proposal to have a grant from DEVxDAO to publish the full code source of the application (https://portal.devxdao.com/public-proposals/72).

Currently, is closed source but as soon as this PR is merged and the last features are done I'll release the full source code on the same repository.

The application will enable users to delegate / undelegate and see current balance between staked tokens and available tokens. (With more features to come for the validators).

The review of the application has been done with the Casper Dev Team (Thu Jul 1, 2021 1pm – 2pm) on Zoom.