### PR TITLE
Display contract arguments

### DIFF
--- a/src/background/SignMessageManager.ts
+++ b/src/background/SignMessageManager.ts
@@ -320,9 +320,7 @@ export default class SignMessageManager extends events.EventEmitter {
           ?.getArgByName('amount')!
           .value()
           .toString();
-      }
 
-      if (deploy.deploy.session.storedContractByHash) {
         deploy.deploy.session.storedContractByHash.args.args.forEach(
           (value, key) => {
             if (value.clType() instanceof CLPublicKeyType) {

--- a/src/popup/components/SignMessagePage.tsx
+++ b/src/popup/components/SignMessagePage.tsx
@@ -117,19 +117,20 @@ class SignMessagePage extends React.Component<
         ]
       });
     } else if (deployData.deployType === 'Contract Deployment') {
+      let deployArgsRows = [];
+
+      for (let [key, value] of Object.entries(deployData.deployArgs)) {
+        if (value.length > 20) {
+          value = this.truncateString(value, 6, 6);
+        }
+        deployArgsRows.push(this.createRow(key, value));
+      }
+
       this.setState({
         rows: [
           ...baseRows,
-          this.createRow(
-            'Validator',
-            this.truncateString(deployData.validator!, 6, 6),
-            deployData.validator
-          ),
-          this.createRow(
-            'Delegator',
-            this.truncateString(deployData.delegator!, 6, 6),
-            deployData.delegator
-          )
+          this.createRow('Contract Arguments', ''),
+          ...deployArgsRows
         ]
       });
     } else {

--- a/src/popup/components/SignMessagePage.tsx
+++ b/src/popup/components/SignMessagePage.tsx
@@ -120,6 +120,8 @@ class SignMessagePage extends React.Component<
       let deployArgsRows = [];
 
       for (let [key, value] of Object.entries(deployData.deployArgs)) {
+        key = key.charAt(0).toUpperCase() + key.slice(1);
+        key = key.replace('_', ' ');
         if (value.length > 20) {
           value = this.truncateString(value, 6, 6);
         }


### PR DESCRIPTION
Partial fixe for #95 
Enable to display all contract arguments and fix "bug" when the deployed contract did not have validator / delegator args.

Result :

![image](https://user-images.githubusercontent.com/8064210/125019928-29fbd780-e078-11eb-8c26-5679e7b7bcb2.png)
