### PR TITLE
Add Netlify Hosting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -24,7 +24,8 @@
         "*://localhost/*",
         "*://*.make.services/*",
         "*://cspr.live/*",
-        "*://*.cspr.live/*"
+        "*://*.cspr.live/*",
+        "*://george-cl-signer-demo.netlify.app/*"
       ],
       "js": ["./scripts/content/content.js"],
       "run_at": "document_start",


### PR DESCRIPTION
I have hosted the Signer Demo project on **Netlify** (the repo remains **private**). As it stands it won't work with the Signer because it's not integrated (the url is not in the `manifest.json`). This PR would add the URL as needed - I would like to do this for the following reasons:

- This would allow us to use the Signer Demo without having to run it locally. This applies also to anyone who would like to explore how the Signer works in a simple environment but doesn't want the hassle of - or doesn't have the technical ability to - pull down the files, build and run it locally.

- I also see the prospect of being able to extend the demo into a sort of _Sandbox_ / _Playground_ where developers can test things out without any risk. Including testing the **JS SDK** which would add more value to the app.

**Relevant [Signer-Demo PR](https://github.com/George-cl/Signer-Demo/pull/3)**
**[Signer-Demo](https://george-cl-signer-demo.netlify.app/) hosted on Netlify**