### PR TITLE
Makes Timeout Configurable

### DIFF
--- a/src/background/AuthController.ts
+++ b/src/background/AuthController.ts
@@ -616,6 +616,11 @@ class AuthController {
   async clearAccount() {
     this.appState.userAccounts.clear();
   }
+
+  @action.bound
+  configureTimeout(durationMins: number) {
+    this.appState.idleTimeoutMins = durationMins;
+  }
 }
 
 export default AuthController;

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -152,4 +152,8 @@ async function setupPopupAPIServer() {
     'connection.isIntegratedSite',
     connectionManager.isIntegratedSite.bind(connectionManager)
   );
+  rpc.register(
+    'account.configureTimeout',
+    accountController.configureTimeout.bind(accountController)
+  );
 }

--- a/src/lib/MemStore.ts
+++ b/src/lib/MemStore.ts
@@ -13,7 +13,7 @@ export class AppState {
   @observable lockoutTimerStarted: boolean = false;
   timerDurationMins: number = 5;
   @observable remainingMins: number = this.timerDurationMins;
-  @observable idleTimeoutMins: number = 1;
+  @observable idleTimeoutMins: number = 2;
   @observable currentTab: Tab | null = null;
   @computed get connectionStatus(): boolean {
     const url = this.currentTab && this.currentTab.url;

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -22,6 +22,7 @@ import AnalyticsProvider from './components/AnalyticsProvider';
 import AccountManagementPage from './components/AccountManagementPage';
 import { ConnectedSitesPage } from './components/ConnectedSitesPage';
 import IdleTimer from 'react-idle-timer';
+import { ConfigureTimeoutPage } from './components/ConfigureTimeout';
 
 export interface AppProps {
   errors: ErrorContainer;
@@ -39,10 +40,6 @@ const App = (props: AppProps) => {
 
   return (
     <div>
-      {/* TODO
-      Lockout time is hardcoded in the appState but this could
-      be made configurable to allow users to set convenient timeouts.
-      */}
       <IdleTimer
         timeout={60 * 1000 * props.authContainer.idleTimeoutMins}
         onIdle={lockOnIdle}
@@ -130,6 +127,13 @@ const App = (props: AppProps) => {
                 connectSignerContainer={props.connectSignerContainer}
                 authContainer={props.authContainer}
               />
+            )}
+          />
+          <Route
+            path={Pages.ConfigureTimeout}
+            exact
+            render={_ => (
+              <ConfigureTimeoutPage accountManager={props.authContainer} />
             )}
           />
         </Switch>

--- a/src/popup/BackgroundManager.ts
+++ b/src/popup/BackgroundManager.ts
@@ -39,6 +39,7 @@ export class BackgroundManager {
     this.appState.activeUserAccount = appState.activeUserAccount;
     this.appState.userAccounts.replace(appState.userAccounts);
     this.appState.unsignedDeploys.replace(appState.unsignedDeploys);
+    this.appState.idleTimeoutMins = appState.idleTimeoutMins;
   }
 
   public unlock(password: string) {
@@ -200,6 +201,12 @@ export class BackgroundManager {
   public isIntegratedSite(hostname: string) {
     return this.errors.withCapture(
       this.rpc.call<boolean>('connection.isIntegratedSite', hostname)
+    );
+  }
+
+  public configureTimeout(durationMins: number) {
+    return this.errors.withCapture(
+      this.rpc.call<void>('account.configureTimeout', durationMins)
     );
   }
 }

--- a/src/popup/components/ConfigureTimeout.tsx
+++ b/src/popup/components/ConfigureTimeout.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import AccountManager from '../container/AccountManager';
 import Pages from '../components/Pages';
-import { List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
+import {
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Typography
+} from '@material-ui/core';
 import { Brightness1 as ActiveIcon } from '@material-ui/icons';
 import { observer } from 'mobx-react';
 import { Redirect } from 'react-router-dom';
@@ -10,8 +16,10 @@ export const ConfigureTimeoutPage = observer(
   (props: { accountManager: AccountManager }) => {
     return props.accountManager.isUnLocked ? (
       <div>
-        <h2>Set Inactivty Timeout</h2>
-        <p>Select the duration until the Signer locks.</p>
+        <h2>Set Idle Timeout</h2>
+        <Typography>
+          Select how long you'd like before the Signer locks due to inactivity.
+        </Typography>
         <List>
           <ListItem
             button={true}

--- a/src/popup/components/ConfigureTimeout.tsx
+++ b/src/popup/components/ConfigureTimeout.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import AccountManager from '../container/AccountManager';
+import Pages from '../components/Pages';
+import { List, ListItem, ListItemIcon, ListItemText } from '@material-ui/core';
+import { Brightness1 as ActiveIcon } from '@material-ui/icons';
+import { observer } from 'mobx-react';
+import { Redirect } from 'react-router-dom';
+
+export const ConfigureTimeoutPage = observer(
+  (props: { accountManager: AccountManager }) => {
+    return props.accountManager.isUnLocked ? (
+      <div>
+        <h2>Set Inactivty Timeout</h2>
+        <p>Select the duration until the Signer locks.</p>
+        <List>
+          <ListItem
+            button={true}
+            onClick={async () => {
+              await props.accountManager.configureTimeout(1);
+            }}
+          >
+            <ListItemText primary="1 minute" />
+            {1 === props.accountManager.idleTimeoutMins && (
+              <ListItemIcon>
+                <ActiveIcon style={{ color: 'green', marginLeft: '30px' }} />
+              </ListItemIcon>
+            )}
+          </ListItem>
+          <ListItem
+            button={true}
+            onClick={async () => {
+              await props.accountManager.configureTimeout(2);
+            }}
+          >
+            <ListItemText primary="2 minutes" />
+            {2 === props.accountManager.idleTimeoutMins && (
+              <ListItemIcon>
+                <ActiveIcon style={{ color: 'green', marginLeft: '30px' }} />
+              </ListItemIcon>
+            )}
+          </ListItem>
+          <ListItem
+            button={true}
+            onClick={async () => {
+              await props.accountManager.configureTimeout(5);
+            }}
+          >
+            <ListItemText primary="5 minutes" />
+            {5 === props.accountManager.idleTimeoutMins && (
+              <ListItemIcon>
+                <ActiveIcon style={{ color: 'green', marginLeft: '30px' }} />
+              </ListItemIcon>
+            )}
+          </ListItem>
+          <ListItem
+            button={true}
+            onClick={async () => {
+              await props.accountManager.configureTimeout(10);
+            }}
+          >
+            <ListItemText primary="10 minutes" />
+            {10 === props.accountManager.idleTimeoutMins && (
+              <ListItemIcon>
+                <ActiveIcon style={{ color: 'green', marginLeft: '30px' }} />
+              </ListItemIcon>
+            )}
+          </ListItem>
+        </List>
+      </div>
+    ) : (
+      <Redirect to={Pages.Home} />
+    );
+  }
+);

--- a/src/popup/components/Menu.tsx
+++ b/src/popup/components/Menu.tsx
@@ -1,19 +1,28 @@
 import React from 'react';
-import AccountManager from '../container/AccountManager';
 import { observer } from 'mobx-react';
-import SettingsIcon from '@material-ui/icons/Settings';
-import CheckIcon from '@material-ui/icons/Check';
-import Icon from '@material-ui/core/Icon';
-import Menu from '@material-ui/core/Menu';
-import LockIcon from '@material-ui/icons/Lock';
-import CloudDownloadIcon from '@material-ui/icons/CloudDownload';
-import WebIcon from '@material-ui/icons/Web';
 import Pages from './Pages';
-import MenuIcon from '@material-ui/icons/Menu';
-import IconButton from '@material-ui/core/IconButton';
-import { List, ListItem, ListItemText, ListSubheader } from '@material-ui/core';
-import Divider from '@material-ui/core/Divider';
 import { Link } from 'react-router-dom';
+import AccountManager from '../container/AccountManager';
+import {
+  Settings as SettingsIcon,
+  Check as CheckIcon,
+  Lock as LockIcon,
+  CloudDownload as CloudDownloadIcon,
+  Web as WebIcon,
+  Menu as MenuIcon,
+  Timer as TimerIcon
+} from '@material-ui/icons';
+import {
+  Icon,
+  IconButton,
+  Menu,
+  List,
+  ListItem,
+  ListItemText,
+  ListSubheader,
+  Divider,
+  Typography
+} from '@material-ui/core';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 
 interface Props {
@@ -126,6 +135,20 @@ const MoreMenu = observer((props: Props) => {
               <ListItemText primary="Download Active Key" />
             </ListItem>
           )}
+          <ListItem
+            dense={true}
+            component={Link}
+            to={Pages.ConfigureTimeout}
+            button
+            onClick={handleClose}
+          >
+            <TimerIcon className={classes.menuIcon} />
+            <ListItemText primary="Timeout" />
+            <Typography variant="overline">
+              {props.authContainer.idleTimeoutMins} min
+              {props.authContainer.idleTimeoutMins === 1 ? '' : 's'}
+            </Typography>
+          </ListItem>
           <ListItem
             dense={true}
             button

--- a/src/popup/components/Pages.ts
+++ b/src/popup/components/Pages.ts
@@ -7,4 +7,5 @@ export default class Pages {
   static readonly AccountManagement = '/account-management';
   static readonly ConnectedSites = '/connected-sites';
   static readonly ConnectSigner = '/connect-signer';
+  static readonly ConfigureTimeout = '/configure-timeout';
 }

--- a/src/popup/container/AccountManager.ts
+++ b/src/popup/container/AccountManager.ts
@@ -192,6 +192,11 @@ class AccountManager {
   get idleTimeoutMins(): number {
     return this.appState.idleTimeoutMins;
   }
+
+  async configureTimeout(durationMins: number) {
+    if (durationMins === this.idleTimeoutMins) return;
+    await this.backgroundManager.configureTimeout(durationMins);
+  }
 }
 
 export default AccountManager;


### PR DESCRIPTION
**Summary**
The current timeout is too short and having it hard-coded is poor UX.
This PR adds a page (accessed via the Menu) which allows users to select the duration of the Inactivity Timeout.
The options are: 1, 2, 5, and 10 minutes with 2 minutes as the default (up from 1 minute).

**Screenshots**
| Menu | Page |
|:----------------------:|:-----------------------:|
| ![Menu-Item](https://user-images.githubusercontent.com/69711689/131233950-4f0548f5-5cbc-49ed-8d9c-335fecf24ce2.png) | ![Configuration-Page](https://user-images.githubusercontent.com/69711689/131234067-b34312db-12ac-4f83-93fb-c856b65c10bb.png) |

**Build**
[Signer Build for PR](https://github.com/casper-ecosystem/signer/files/7071691/casperlabs_signer-1.3.0.zip)

