### PR TITLE
UI/UX Tweaks to the New Vault Screen

### DIFF
--- a/src/popup/components/Home.tsx
+++ b/src/popup/components/Home.tsx
@@ -154,8 +154,9 @@ class Home extends React.Component<
 
           <Grid item container>
             <form style={{ textAlign: 'center', width: '100%' }}>
-              <FormControl style={{ width: '80%' }}>
+              <FormControl style={{ width: '80%', float: 'left' }}>
                 <TextFieldWithFormState
+                  autoFocus
                   fieldState={
                     this.props.homeContainer.homeForm.$.setPasswordField
                   }
@@ -213,7 +214,7 @@ class Home extends React.Component<
                 .hasBeenValidated &&
                 !this.props.homeContainer.homeForm.$.setPasswordField
                   .hasError && (
-                  <FormControl fullWidth>
+                  <FormControl style={{ width: '80%', float: 'left' }}>
                     <TextFieldWithFormState
                       fieldState={
                         this.props.homeContainer.homeForm.$.confirmPasswordField


### PR DESCRIPTION
### Summary
The _Set_ and _Confirm_ password fields were misaligned and the latter was wider which made comparing text between the two inputs more difficult.
This PR corrects the misalignment, makes them equal width and adds autofocus to the set password field.

### Screenshots
![New Vault Screen](https://user-images.githubusercontent.com/69711689/131234811-6cd0c7ad-59f6-48d6-8792-4e8202b38e57.png)

### Files
[Signer with UI/UX tweaks](https://github.com/casper-ecosystem/signer/files/7106687/casperlabs_signer-1.3.0.zip)
