### PR TITLE
Integrate CasperStats with Signer

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -28,7 +28,9 @@
         "*://casperholders.io/*",
         "*://*.casperholders.io/*",
         "*://casperholders.com/*",
-        "*://*.casperholders.com/*"
+        "*://*.casperholders.com/*",
+        "*://*.casperstats.io/*",
+        "*://casperstats.io/*"
       ],
       "js": ["./scripts/content/content.js"],
       "run_at": "document_start",


### PR DESCRIPTION
Adds the casperstats.io url to the manifest to allow use of the Signer on the site.