### PR TITLE
EVENT BUS: Send State Data on Initial Page Load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.14.6",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",

--- a/src/background/ConnectionManager.ts
+++ b/src/background/ConnectionManager.ts
@@ -52,6 +52,7 @@ export default class ConnectionManager {
         const url = parseTabURL(tab.url);
         if (url && !BLACKLIST_PROTOCOLS.includes(url.protocol)) {
           this.appState.currentTab = url ? { tabId, url: url.hostname } : null;
+          updateStatusEvent(appState, 'initialState');
         }
       }
     });

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -2,6 +2,7 @@ import { AppState } from '../lib/MemStore';
 import { browser } from 'webextension-polyfill-ts';
 
 export type eventType =
+  | 'initialState'
   | 'connected'
   | 'disconnected'
   | 'tabUpdated'

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -1,6 +1,14 @@
 import { AppState } from '../lib/MemStore';
 import { browser } from 'webextension-polyfill-ts';
 
+export type eventType =
+  | 'connected'
+  | 'disconnected'
+  | 'tabUpdated'
+  | 'activeKeyChanged'
+  | 'locked'
+  | 'unlocked';
+
 export function updateBadge(appState: AppState) {
   let label = '';
   let count =
@@ -18,7 +26,7 @@ export function updateBadge(appState: AppState) {
   browser.browserAction.setBadgeBackgroundColor({ color: 'red' });
 }
 
-export function updateStatusEvent(appState: AppState, msg: string) {
+export function updateStatusEvent(appState: AppState, msg: eventType) {
   if (!appState.currentTab) return;
   const savedSite = appState.connectedSites.find(
     s => s.url === appState.currentTab!.url


### PR DESCRIPTION
This will form part of the **1.4.1**  release.

As requested by @KillianH this PR pushes the Signer state on initial page load via a new event: `signer:initialState` Which can be listened to in the same way as the current events:

``` TypeScript
window.addEventListener('signer:initialState', data => {
    console.log(data.detail);
}
```

### Asset
[Signer 1.4.1-Initial-State](https://github.com/casper-ecosystem/signer/files/7214534/casperlabs_signer-1.4.1.zip)
