### PR TITLE
Back Up Prompt on Account Deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.14.6",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.4.0",
+  "version": "1.4.2",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",
@@ -20,7 +20,7 @@
   "content_scripts": [
     {
       "matches": [
-        "*://*.casperlabs.io/*", 
+        "*://*.casperlabs.io/*",
         "*://localhost/*",
         "*://*.make.services/*",
         "*://cspr.live/*",
@@ -32,12 +32,18 @@
         "*://*.casperstats.io/*",
         "*://casperstats.io/*"
       ],
-      "js": ["./scripts/content/content.js"],
+      "js": [
+        "./scripts/content/content.js"
+      ],
       "run_at": "document_start",
       "all_frames": true
     }
   ],
-  "permissions": ["notifications", "storage", "tabs"],
+  "permissions": [
+    "notifications",
+    "storage",
+    "tabs"
+  ],
   "web_accessible_resources": [
     "scripts/content/inpage.js",
     "scripts/content/signerTestMethods.js",

--- a/src/@types/models.d.ts
+++ b/src/@types/models.d.ts
@@ -3,7 +3,8 @@ import { Keys } from 'casper-js-sdk';
 interface KeyPairWithAlias {
   // Human readable alias.
   alias: string;
-  KeyPair: Keys.Ed25519 | Keys.Secp256K1;
+  keyPair: Keys.Ed25519 | Keys.Secp256K1;
+  backedUp: boolean;
 }
 
 type ByteArray = Uint8Array;

--- a/src/background/SigningManager.ts
+++ b/src/background/SigningManager.ts
@@ -110,7 +110,7 @@ export default class SigningManager extends events.EventEmitter {
    */
   public getActivePublicKey() {
     return new Promise<string>((resolve, reject) => {
-      let publicKey = this.appState.activeUserAccount?.KeyPair.publicKey;
+      let publicKey = this.appState.activeUserAccount?.keyPair.publicKey;
       if (!this.appState.connectionStatus) {
         return reject(new Error('Please connect to the Signer to read key'));
       }
@@ -251,7 +251,7 @@ export default class SigningManager extends events.EventEmitter {
     if (!this.appState.activeUserAccount) {
       throw new Error(`No Active Account!`);
     }
-    let activeKeyPair = this.appState.activeUserAccount.KeyPair;
+    let activeKeyPair = this.appState.activeUserAccount.keyPair;
     if (!deployData.deploy) {
       deployData.error = new Error('Cannot sign null deploy!');
       this.saveAndEmitEventIfNeeded(deployData);
@@ -426,11 +426,11 @@ export default class SigningManager extends events.EventEmitter {
         throw new Error('Message or public key was null/undefined');
       if (
         this.appState.userAccounts.some(
-          account => account.KeyPair.publicKey.toHex() !== signingPublicKey
+          account => account.keyPair.publicKey.toHex() !== signingPublicKey
         )
       )
         throw new Error('Provided key is not present in vault.');
-      const activeKeyPair = this.appState.activeUserAccount?.KeyPair;
+      const activeKeyPair = this.appState.activeUserAccount?.keyPair;
       if (!activeKeyPair) throw new Error('No active account');
       if (activeKeyPair.publicKey.toHex() !== signingPublicKey)
         throw new Error(
@@ -470,7 +470,7 @@ export default class SigningManager extends events.EventEmitter {
           case 'signed':
             if (processedMessage.messageBytes) {
               this.appState.unsignedMessages.remove(processedMessage);
-              if (activeKeyPair !== this.appState.activeUserAccount?.KeyPair)
+              if (activeKeyPair !== this.appState.activeUserAccount?.keyPair)
                 throw new Error('Active account changed during signing.');
               const signature = signFormattedMessage(
                 activeKeyPair,
@@ -502,7 +502,7 @@ export default class SigningManager extends events.EventEmitter {
     if (!this.appState.activeUserAccount) {
       throw new Error(`No Active Account!`);
     }
-    let activeKeyPair = this.appState.activeUserAccount.KeyPair;
+    let activeKeyPair = this.appState.activeUserAccount.keyPair;
     if (!messageWithId.messageBytes || !messageWithId.messageString) {
       messageWithId.error = new Error(
         `Cannot sign message: ${

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -62,6 +62,10 @@ async function setupPopupAPIServer() {
     accountController.reorderAccount.bind(accountController)
   );
   rpc.register(
+    'account.isBackedUp',
+    accountController.isBackedUp.bind(accountController)
+  );
+  rpc.register(
     'account.getActiveUserAccount',
     accountController.getActiveUserAccount.bind(accountController)
   );

--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -33,7 +33,7 @@ export function updateStatusEvent(appState: AppState, msg: string) {
         isConnected: isUnlocked ? savedSite.isConnected : null,
         activeKey:
           isConnected && isUnlocked && activeUserAccount
-            ? activeUserAccount.KeyPair.publicKey.toHex()
+            ? activeUserAccount.keyPair.publicKey.toHex()
             : null
       }
     });

--- a/src/popup/BackgroundManager.ts
+++ b/src/popup/BackgroundManager.ts
@@ -60,14 +60,16 @@ export class BackgroundManager {
   public importUserAccount(
     name: string,
     secretKeyBase64: string,
-    algorithm: string
+    algorithm: string,
+    backedUp: boolean
   ) {
     return this.errors.withCapture(
       this.rpc.call<void>(
         'account.importUserAccount',
         name,
         secretKeyBase64,
-        algorithm
+        algorithm,
+        backedUp
       )
     );
   }
@@ -81,6 +83,12 @@ export class BackgroundManager {
   public removeUserAccount(name: string) {
     return this.errors.withCapture(
       this.rpc.call<void>('account.removeUserAccount', name)
+    );
+  }
+
+  public isBackedUp(alias: string) {
+    return this.errors.withCapture(
+      this.rpc.call<boolean>('account.isBackedUp', alias)
     );
   }
 

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -195,7 +195,8 @@ class AccountManagementPage extends React.Component<Props, State> {
   };
 
   render() {
-    return !this.props.authContainer.isUnLocked ? (
+    return !this.props.authContainer.isUnLocked ||
+      !this.props.authContainer.userAccounts[0] ? (
       <Redirect to={Pages.Home} />
     ) : (
       <React.Fragment>
@@ -239,28 +240,16 @@ class AccountManagementPage extends React.Component<Props, State> {
                                       <EditIcon />
                                     </IconButton>
                                   </Tooltip>
-                                  {this.props.authContainer.userAccounts
-                                    .length > 1 ? (
-                                    <Tooltip title="Delete">
-                                      <IconButton
-                                        edge={'end'}
-                                        onClick={() => {
-                                          this.handleClickRemove(item.alias);
-                                        }}
-                                      >
-                                        <DeleteIcon />
-                                      </IconButton>
-                                    </Tooltip>
-                                  ) : (
-                                    // span is required for tooltip to work on disabled button
-                                    <Tooltip title="Can't delete only account">
-                                      <span>
-                                        <IconButton edge={'end'} disabled>
-                                          <DeleteIcon />
-                                        </IconButton>
-                                      </span>
-                                    </Tooltip>
-                                  )}
+                                  <Tooltip title="Delete">
+                                    <IconButton
+                                      edge={'end'}
+                                      onClick={() => {
+                                        this.handleClickRemove(item.alias);
+                                      }}
+                                    >
+                                      <DeleteIcon />
+                                    </IconButton>
+                                  </Tooltip>
                                   <Tooltip title="View">
                                     <IconButton
                                       edge={'end'}

--- a/src/popup/components/AccountManagementPage.tsx
+++ b/src/popup/components/AccountManagementPage.tsx
@@ -154,17 +154,44 @@ class AccountManagementPage extends React.Component<Props, State> {
     );
   };
 
-  handleClickRemove = (name: string) => {
-    confirm(
-      <div className="text-danger">Remove account</div>,
-      <span>
-        This account will be permanently deleted. Confirm password to remove
-        account: <b>{name}</b>
-      </span>,
-      'Remove',
-      'Cancel',
-      { requirePassword: true }
-    ).then(() => this.props.authContainer.removeUserAccount(name));
+  handleClickRemove = async (name: string) => {
+    let backedUp = await this.props.authContainer.isBackedUp(name);
+    !backedUp
+      ? confirm(
+          <div className="text-danger">Back up account</div>,
+          <span>
+            This account has not been backed up.
+            <br />
+            <b>
+              You will not be able to recover this account without your key.
+            </b>
+            <br />
+            <br />
+            Would you like to download the key files for {name}?
+          </span>,
+          'Download',
+          'Cancel',
+          {}
+        ).then(
+          async () => await this.props.authContainer.downloadPemFiles(name)
+        )
+      : confirm(
+          <div className="text-danger">Remove account</div>,
+          <span>
+            This account will be permanently deleted. Confirm password to remove
+            account: <b>{name}</b>
+          </span>,
+          'Remove',
+          'Cancel',
+          {
+            requirePassword: true,
+            requireCheckbox: true,
+            checkboxText:
+              'I understand I will need the key files to recover this account'
+          }
+        ).then(
+          async () => await this.props.authContainer.removeUserAccount(name)
+        );
   };
 
   render() {

--- a/src/popup/components/AccountPage.tsx
+++ b/src/popup/components/AccountPage.tsx
@@ -25,6 +25,11 @@ import { KeyPairWithAlias } from '../../@types/models';
 import Pages from './Pages';
 import { confirm } from './Confirmation';
 
+enum method {
+  'Created',
+  'Imported'
+}
+
 const styles = (theme: Theme) =>
   createStyles({
     root: {
@@ -89,21 +94,23 @@ class AccountPage extends React.Component<Props, State> {
       case 'ed25519': {
         keyPair = {
           alias: formData.name.$,
-          KeyPair: Keys.Ed25519.parseKeyPair(
+          keyPair: Keys.Ed25519.parseKeyPair(
             decodeBase16(formData.publicKey.$.substring(2)),
             decodeBase64(formData.secretKeyBase64.value)
-          )
+          ),
+          backedUp: false
         };
         break;
       }
       case 'secp256k1': {
         keyPair = {
           alias: formData.name.$,
-          KeyPair: Keys.Secp256K1.parseKeyPair(
+          keyPair: Keys.Secp256K1.parseKeyPair(
             decodeBase16(formData.publicKey.$.substring(2)),
             decodeBase64(formData.secretKeyBase64.value),
             'raw'
-          )
+          ),
+          backedUp: false
         };
         break;
       }
@@ -116,21 +123,22 @@ class AccountPage extends React.Component<Props, State> {
       await this.props.authContainer.downloadPemFiles(keyPair.alias);
     }
 
-    await this._onSubmit();
+    await this._onSubmit(method.Created);
   }
 
   onImportAccount() {
     if (this.accountForm.submitDisabled) {
       return;
     }
-    this._onSubmit();
+    this._onSubmit(method.Imported);
   }
 
-  async _onSubmit() {
+  async _onSubmit(source: method) {
     await this.props.authContainer.importUserAccount(
       this.accountForm.name.$,
       this.accountForm.secretKeyBase64.value,
-      this.accountForm.algorithm.$
+      this.accountForm.algorithm.$,
+      source === method.Created ? false : true
     );
     this.props.history.push(Pages.Home);
     this.props.history.replace(Pages.Home);

--- a/src/popup/components/Confirmation.tsx
+++ b/src/popup/components/Confirmation.tsx
@@ -59,12 +59,32 @@ class Confirmation extends React.Component<Props, { boxChecked: boolean }> {
         onClose={this.props.dismiss}
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
+        style={{ margin: '-1rem -0.5rem' }}
       >
         <DialogTitle id="alert-dialog-title">{this.props.title}</DialogTitle>
         <DialogContent>
           <DialogContentText id="alert-dialog-description">
             {this.props.confirmation}
           </DialogContentText>
+          {this.props.options.requireCheckbox && (
+            <FormControlLabel
+              control={
+                <Checkbox
+                  style={{ alignSelf: 'flex-start' }}
+                  checked={this.state.boxChecked}
+                  onChange={this.handleCheckboxChange}
+                />
+              }
+              label={this.props.options.checkboxText}
+              style={{
+                fontSize: '0.6rem',
+                marginRight: '-1rem',
+                marginBottom: this.props.options.requirePassword
+                  ? '0.5rem'
+                  : 'auto'
+              }}
+            />
+          )}
           {this.props.options.requirePassword && (
             <FormControl>
               <TextFieldWithFormState
@@ -78,19 +98,6 @@ class Confirmation extends React.Component<Props, { boxChecked: boolean }> {
               />
             </FormControl>
           )}
-          {this.props.options.requireCheckbox && (
-            <FormControlLabel
-              control={
-                <Checkbox
-                  style={{ alignSelf: 'flex-start' }}
-                  checked={this.state.boxChecked}
-                  onChange={this.handleCheckboxChange}
-                />
-              }
-              label={this.props.options.checkboxText}
-              // Needs styling - the font's a bit big
-            />
-          )}
         </DialogContent>
         <DialogActions>
           <Button
@@ -101,7 +108,34 @@ class Confirmation extends React.Component<Props, { boxChecked: boolean }> {
           >
             {this.props.cancelLabel}
           </Button>
-          {this.props.options.requirePassword ? (
+          {this.props.options.requireCheckbox &&
+          this.props.options.requirePassword ? (
+            <FormControl>
+              <Button
+                type="submit"
+                // TODO: Disable doesn't work - doesn't enable when field is non-null.
+                disabled={!this.state.boxChecked}
+                onClick={async () => {
+                  let givenPassword =
+                    this.accountManager.confirmPasswordForm.$
+                      .confirmPasswordField.$;
+                  try {
+                    await this.accountManager.confirmPassword(givenPassword);
+                    this.accountManager.confirmPasswordForm.$.confirmPasswordField.reset();
+                    this.errors.dismissLast();
+                    this.props.proceed();
+                  } catch (e) {
+                    this.accountManager.confirmPasswordForm.$.confirmPasswordField.setError(
+                      (e as Error).message
+                    );
+                  }
+                }}
+                color="primary"
+              >
+                {this.props.proceedLabel}
+              </Button>
+            </FormControl>
+          ) : this.props.options.requirePassword ? (
             <FormControl>
               <Button
                 type="submit"
@@ -118,7 +152,7 @@ class Confirmation extends React.Component<Props, { boxChecked: boolean }> {
                     this.props.proceed();
                   } catch (e) {
                     this.accountManager.confirmPasswordForm.$.confirmPasswordField.setError(
-                      e.message
+                      (e as Error).message
                     );
                   }
                 }}

--- a/src/popup/components/Home.tsx
+++ b/src/popup/components/Home.tsx
@@ -414,7 +414,7 @@ class Home extends React.Component<
                       this.props.errors.dismissLast();
                     } catch (e) {
                       this.props.homeContainer.homeForm.$.unlockPasswordField.setError(
-                        e.message
+                        (e as Error).message
                       );
                     }
                   }}

--- a/src/popup/components/Home.tsx
+++ b/src/popup/components/Home.tsx
@@ -341,13 +341,12 @@ class Home extends React.Component<
   resetVaultOnClick() {
     confirm(
       <div className="text-danger">Reset Vault</div>,
-      'Resetting vault will permanently delete all accounts.',
+      'Resetting vault will permanently delete all accounts. You must have key files backed up if you want to recover them in the future.',
       'Reset',
       'Cancel',
       {
         requireCheckbox: true,
-        checkboxText:
-          'I understand that I will not be able to recover any accounts stored in my vault unless I have backed them up.'
+        checkboxText: 'I have read and understand the above.'
       }
     ).then(() => {
       this.props.authContainer.resetVault();

--- a/src/popup/container/AccountManager.ts
+++ b/src/popup/container/AccountManager.ts
@@ -22,12 +22,14 @@ class AccountManager {
   async importUserAccount(
     name: string,
     secretKeyBase64: string,
-    algorithm: string
+    algorithm: string,
+    backedUp: boolean
   ) {
     return this.backgroundManager.importUserAccount(
       name,
       secretKeyBase64,
-      algorithm
+      algorithm,
+      backedUp
     );
   }
 
@@ -65,6 +67,10 @@ class AccountManager {
   @computed
   get userAccounts(): IObservableArray<KeyPairWithAlias> {
     return this.appState.userAccounts;
+  }
+
+  async isBackedUp(alias: string) {
+    return await this.backgroundManager.isBackedUp(alias);
   }
 
   async downloadPemFiles(accountAlias: string) {
@@ -177,6 +183,7 @@ class AccountManager {
   @computed
   get confirmPasswordDisabled(): boolean {
     let disabled =
+      !this.confirmPasswordForm.$.confirmPasswordField.$ ||
       !this.confirmPasswordForm.$.confirmPasswordField.hasBeenValidated ||
       (this.confirmPasswordForm.$.confirmPasswordField.hasBeenValidated &&
         this.confirmPasswordForm.$.confirmPasswordField.hasError);


### PR DESCRIPTION
This PR will form part of **1.4.2**.

- Users will not be able to delete keys that have not been backed up (created in the Signer but not downloaded).
- Imported keys are counted as 'backed up' since there had to be a file locally to start with.
- When deleting keys that have been backed up users still need to enter their password and acknowledge they should have access to the back ups.
- Users are no longer prevented from deleting the last account.

Users are technically forced to 'download' their keys before being allowed to remove the account. However, when the File Explorer opens they can just cancel it - _this isn't advised but it is a workaround for those who wish to remove an account without downloading anything._

| Download Prompt | Deletion Prompt |
| :----------------------: | :--------------------: |
|![Prompt](https://user-images.githubusercontent.com/69711689/136714046-e675c332-4851-4a85-81c6-9b76c012d636.png) | ![Prompt](https://user-images.githubusercontent.com/69711689/136714147-39df2a48-63b9-424f-8ace-66f20c4aaac7.png) |

### Asset
[Signer v1.4.2 (Backup Prompt)](https://github.com/casper-ecosystem/signer/files/7318384/casperlabs_signer-1.4.2.zip)


