### PR TITLE
Support target containing PublicKey

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "casperlabs-signer",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dependencies": {
         "@babel/core": "^7.14.6",
         "@extend-chrome/storage": "^1.5.0",
@@ -26,7 +26,7 @@
         "@types/react-dom": "^16.9.14",
         "axios": "^0.21.1",
         "browser-passworder": "^2.0.3",
-        "casper-js-sdk": "^2.5.1",
+        "casper-js-sdk": "^2.7.1",
         "copy-to-clipboard": "^3.3.1",
         "download": "^8.0.0",
         "eslint-config-react-app": "^6.0.0",
@@ -7292,9 +7292,9 @@
       "dev": true
     },
     "node_modules/casper-js-sdk": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/casper-js-sdk/-/casper-js-sdk-2.5.2.tgz",
-      "integrity": "sha512-c2Lww/97Jo9LT/uuPXFKeJSPiLoNe8KVQJ9zdUWJT9LhBBchDjsYlb1/YI0J19gJ+KZSuido/r9Vb8QOhonGzQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/casper-js-sdk/-/casper-js-sdk-2.7.1.tgz",
+      "integrity": "sha512-vc9sXm4UEIjyMkxdsgy1QXiCW7uRg3+v6gSW2vhPk8shjtYdr/51Q+WrXy2cyqIc8a6/P/xiDGcLcOht+/AGIg==",
       "dependencies": {
         "@ethersproject/bignumber": "^5.0.8",
         "@ethersproject/bytes": "^5.0.5",
@@ -36483,9 +36483,9 @@
       "dev": true
     },
     "casper-js-sdk": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/casper-js-sdk/-/casper-js-sdk-2.5.2.tgz",
-      "integrity": "sha512-c2Lww/97Jo9LT/uuPXFKeJSPiLoNe8KVQJ9zdUWJT9LhBBchDjsYlb1/YI0J19gJ+KZSuido/r9Vb8QOhonGzQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/casper-js-sdk/-/casper-js-sdk-2.7.1.tgz",
+      "integrity": "sha512-vc9sXm4UEIjyMkxdsgy1QXiCW7uRg3+v6gSW2vhPk8shjtYdr/51Q+WrXy2cyqIc8a6/P/xiDGcLcOht+/AGIg==",
       "requires": {
         "@ethersproject/bignumber": "^5.0.8",
         "@ethersproject/bytes": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.14.6",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/react-dom": "^16.9.14",
     "axios": "^0.21.1",
     "browser-passworder": "^2.0.3",
-    "casper-js-sdk": "^2.5.1",
+    "casper-js-sdk": "^2.7.1",
     "copy-to-clipboard": "^3.3.1",
     "download": "^8.0.0",
     "eslint-config-react-app": "^6.0.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.4.3",
+  "version": "1.4.4",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",

--- a/src/background/SigningManager.ts
+++ b/src/background/SigningManager.ts
@@ -574,6 +574,7 @@ export default class SigningManager extends events.EventEmitter {
     transferDeploy: DeployUtil.Transfer,
     providedPublicKeyHex: string
   ) {
+    const pkHex = providedPublicKeyHex.toLowerCase();
     const transferArgs: argDict = {};
 
     const targetArg = transferDeploy?.getArgByName('target')!;
@@ -584,20 +585,20 @@ export default class SigningManager extends events.EventEmitter {
     // confirm hash of provided public key matches target account hash from deploy
     if (targetArg.clType().tag === CLTypeTag.ByteArray) {
       targetToDisplay = encodeBase16(targetArg.value());
-      this.verifyTargetAccountMatch(providedPublicKeyHex, targetToDisplay);
+      this.verifyTargetAccountMatch(pkHex, targetToDisplay);
     }
 
     // If deploy is created using version of SDK gte then 2.7.0
-    // In fact this logic can be removed in future as well as providedPublicKeyHex param
+    // In fact this logic can be removed in future as well as pkHex param
     if (targetArg.clType().tag === CLTypeTag.PublicKey) {
-      if ((targetArg as CLPublicKey).toHex() !== providedPublicKeyHex) {
+      if ((targetArg as CLPublicKey).toHex() !== pkHex) {
         throw new Error(
           "Provided target public key doesn't match the one in deploy"
         );
       }
     }
 
-    const recipient = providedPublicKeyHex;
+    const recipient = pkHex;
     const amount = transferDeploy?.getArgByName('amount')!.value().toString();
     const id = transferDeploy
       ?.getArgByName('id')!

--- a/src/background/SigningManager.ts
+++ b/src/background/SigningManager.ts
@@ -9,7 +9,8 @@ import {
   CLByteArrayType,
   CLAccountHashType,
   formatMessageWithHeaders,
-  signFormattedMessage
+  signFormattedMessage,
+  CLTypeTag
 } from 'casper-js-sdk';
 import { JsonTypes } from 'typedjson';
 export type deployStatus = 'unsigned' | 'signed' | 'failed';
@@ -577,21 +578,18 @@ export default class SigningManager extends events.EventEmitter {
 
     const targetArg = transferDeploy?.getArgByName('target')!;
 
-    const CLTYPE_PUBLIC_KEY_TAG = 22;
-    const CLTYPE_HASH_TAG = 15;
-
     let targetToDisplay;
 
     // If deploy is created using older version of SDK
     // confirm hash of provided public key matches target account hash from deploy
-    if (targetArg.clType().tag === CLTYPE_HASH_TAG) {
+    if (targetArg.clType().tag === CLTypeTag.ByteArray) {
       targetToDisplay = encodeBase16(targetArg.value());
       this.verifyTargetAccountMatch(providedPublicKeyHex, targetToDisplay);
     }
 
     // If deploy is created using version of SDK gte then 2.7.0
     // In fact this logic can be removed in future as well as providedPublicKeyHex param
-    if (targetArg.clType().tag === CLTYPE_PUBLIC_KEY_TAG) {
+    if (targetArg.clType().tag === CLTypeTag.PublicKey) {
       if ((targetArg as CLPublicKey).toHex() !== providedPublicKeyHex) {
         throw new Error(
           "Provided target public key doesn't match the one in deploy"


### PR DESCRIPTION
* Signer introduced some time ago API that gives users the ability to provide hex format `PublicKey` (along with `Deploy` object which contained only `AccountHash` - and we wanted to display PK to the user) to `sign` function
* It was also checking if the provided `PublickKey` converted to `account-hash` is the same as target `account-hash`
* The problem was that when we released `casper-js-sdk 2.7.0` which was using `PublicKey` as a target, we didn't test it with Signer.