### PR TITLE
Integration - Gitcoin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.14.6",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.4.4",
+  "version": "1.4.5",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -41,7 +41,9 @@
         "*://*.metacask.com/*",
         "*://*.newland.finance/*",
         "*://*.huobiapps/*",
-        "*://*.singlecoin.xyz/*"
+        "*://*.singlecoin.xyz/*",
+        "*://*.gitcoin.co/*",
+        "*://gitcoin.co/*"
       ],
       "js": [
         "./scripts/content/content.js"


### PR DESCRIPTION
Adds Gitcoin URLs to manifest to allow content script injection on their site.

### URLs
```
 "*://*.gitcoin.co/*"
 "*://gitcoin.co/*"
```