### PR TITLE
Integration - Decentralized Lending Network (DLN)

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -42,6 +42,8 @@
         "*://*.newland.finance/*",
         "*://*.huobiapps/*",
         "*://*.singlecoin.xyz/*"
+        "*://*.dlndao.org/*"
+        "*://*.dln.org/*"
       ],
       "js": [
         "./scripts/content/content.js"


### PR DESCRIPTION
We are developing DLN, Decentralized Lending Network, Grant # 74.
We would like to white list the dev and live domains so that our users can connect with the standard Casper Signer without having to install the dev version for the signer.
The current version that we are using is the dev version with the manifest updated like this.
Thanks