### PR TITLE
Integration - BoringSwap

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -46,6 +46,8 @@
         "*://*.dln.org/*",
         "*://*.casper.credentia.me/*",
         "*://analytics.caspercommunity.io/*",
+        "*://*.boringswap.com/*",
+        "*://boringswap.com/*",
         "*://*.gitcoin.co/*",
         "*://gitcoin.co/*"
       ],


### PR DESCRIPTION
Hello Signer Team.

We are the team from Japan and we build BoringSwap as a DEX base on casper network.
We want add our domain to whitelist, so our testers run integration test on both Testnet and Mainnet without having install dev version of signer.

Thank you!