### PR TITLE
Increases Width of Deploy Signing window

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.14.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.4.7",
+  "version": "1.4.6",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.14.6",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.4.6",
+  "version": "1.4.7",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.4.7",
+  "version": "1.4.6",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",

--- a/src/background/PopupManager.ts
+++ b/src/background/PopupManager.ts
@@ -9,11 +9,12 @@ export type openPurpose =
   | 'importAccount'
   | 'noAccount';
 
-// Popup window dimensions
-const normalPopupWidth = 300;
-const normalPopupHeight = 480;
-const expandedPopupHeight = 820;
-const expandedPopupWidth = 430;
+export const popupDimensions = {
+  defaultWidth: 300,
+  defaultHeight: 480,
+  expandedWidth: 430,
+  expandedHeight: 820
+};
 
 // Pads around popup window
 const popupBuffer = {
@@ -30,7 +31,9 @@ export default class PopupManager {
       .getCurrent()
       .then(window => {
         let windowWidth =
-          window.width === undefined || null ? normalPopupWidth : window.width;
+          window.width === undefined || null
+            ? popupDimensions.defaultWidth
+            : window.width;
         let xOffset = window.left === undefined || null ? 0 : window.left;
         let yOffset = window.top === undefined || null ? 0 : window.top;
         browser.windows.create({
@@ -40,10 +43,18 @@ export default class PopupManager {
               : 'index.html?#/',
           type: 'popup',
           height:
-            openFor === 'signDeploy' ? expandedPopupHeight : normalPopupHeight,
+            openFor === 'signDeploy'
+              ? popupDimensions.expandedHeight
+              : popupDimensions.defaultHeight,
           width:
-            openFor === 'signDeploy' ? expandedPopupWidth : normalPopupWidth,
-          left: windowWidth + xOffset - normalPopupWidth - popupBuffer.right,
+            openFor === 'signDeploy'
+              ? popupDimensions.expandedWidth
+              : popupDimensions.defaultWidth,
+          left:
+            windowWidth +
+            xOffset -
+            popupDimensions.defaultWidth -
+            popupBuffer.right,
           top: yOffset + popupBuffer.top
         });
       })

--- a/src/background/PopupManager.ts
+++ b/src/background/PopupManager.ts
@@ -9,9 +9,12 @@ export type openPurpose =
   | 'importAccount'
   | 'noAccount';
 
+// Popup window dimensions
 const normalPopupWidth = 300;
 const normalPopupHeight = 480;
 const expandedPopupHeight = 820;
+const expandedPopupWidth = 430;
+
 // Pads around popup window
 const popupBuffer = {
   right: 20,
@@ -38,7 +41,8 @@ export default class PopupManager {
           type: 'popup',
           height:
             openFor === 'signDeploy' ? expandedPopupHeight : normalPopupHeight,
-          width: normalPopupWidth,
+          width:
+            openFor === 'signDeploy' ? expandedPopupWidth : normalPopupWidth,
           left: windowWidth + xOffset - normalPopupWidth - popupBuffer.right,
           top: yOffset + popupBuffer.top
         });

--- a/src/background/PopupManager.ts
+++ b/src/background/PopupManager.ts
@@ -1,6 +1,7 @@
 // size of the popup
 
 import { browser } from 'webextension-polyfill-ts';
+import { popupDimensions } from '../shared/constants';
 
 export type openPurpose =
   | 'connect'
@@ -8,13 +9,6 @@ export type openPurpose =
   | 'signMessage'
   | 'importAccount'
   | 'noAccount';
-
-export const popupDimensions = {
-  defaultWidth: 300,
-  defaultHeight: 480,
-  expandedWidth: 430,
-  expandedHeight: 820
-};
 
 // Pads around popup window
 const popupBuffer = {

--- a/src/popup/components/MainAppBar.tsx
+++ b/src/popup/components/MainAppBar.tsx
@@ -18,6 +18,7 @@ import confirmConnect from './ConfirmConnect';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
+      width: '100vw',
       flexGrow: 1,
       color: '#c4c4c4',
       backgroundColor: 'var(--cspr-dark-blue)'

--- a/src/popup/components/SignDeployPage.tsx
+++ b/src/popup/components/SignDeployPage.tsx
@@ -28,8 +28,7 @@ import {
   numberWithSpaces,
   motesToCSPR
 } from '../../background/utils';
-import { popupDimensions } from '../../background/PopupManager';
-
+import { popupDimensions } from '../../shared/constants';
 const styles = () => ({
   tooltip: {
     fontSize: '.8rem',

--- a/src/popup/components/SignDeployPage.tsx
+++ b/src/popup/components/SignDeployPage.tsx
@@ -164,12 +164,12 @@ class SignDeployPage extends React.Component<
     if (this.state.deployToSign && this.props.authContainer.isUnLocked) {
       const deployId = this.props.signingContainer.deployToSign?.id;
       return (
-        <div style={{ flexGrow: 1, marginTop: '-30px' }}>
+        <div style={{ flexGrow: 1, marginTop: '-30px', width: '430px' }}>
           <Typography align={'center'} variant={'h6'}>
             Signature Request
           </Typography>
           <TableContainer>
-            <Table style={{ maxWidth: '100%' }}>
+            <Table style={{ width: '90%' }}>
               <TableBody>
                 {this.state.genericRows.map((row: any) =>
                   row.key === 'Amount' || row.key === 'Payment' ? (

--- a/src/popup/components/SignDeployPage.tsx
+++ b/src/popup/components/SignDeployPage.tsx
@@ -28,6 +28,7 @@ import {
   numberWithSpaces,
   motesToCSPR
 } from '../../background/utils';
+import { popupDimensions } from '../../background/PopupManager';
 
 const styles = () => ({
   tooltip: {
@@ -164,7 +165,13 @@ class SignDeployPage extends React.Component<
     if (this.state.deployToSign && this.props.authContainer.isUnLocked) {
       const deployId = this.props.signingContainer.deployToSign?.id;
       return (
-        <div style={{ flexGrow: 1, marginTop: '-30px', width: '430px' }}>
+        <div
+          style={{
+            flexGrow: 1,
+            marginTop: '-30px',
+            width: popupDimensions.expandedWidth
+          }}
+        >
           <Typography align={'center'} variant={'h6'}>
             Signature Request
           </Typography>

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,0 +1,10 @@
+/**
+ *  Constants required by both the background and popup components.
+ */
+
+export const popupDimensions = {
+  defaultWidth: 300,
+  defaultHeight: 480,
+  expandedWidth: 430,
+  expandedHeight: 820
+};


### PR DESCRIPTION
This PR makes the window wider when signing deploys - this is to make it easier to review the information and should reduce the need for scrolling.

### Asset
[Signer for PR193](https://github.com/casper-ecosystem/signer/files/7871502/casperlabs_signer-1.4.7.zip)

