### PR TITLE
Fix for Event Name Collisions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.14.6",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.4.6",
+  "version": "1.4.7",
   "name": "CasperLabs Signer",
   "author": "https://casperlabs.io",
   "description": "CasperLabs Signer tool for signing transactions on the blockchain.",


### PR DESCRIPTION
This PR prefixes the events emitted by the `SigningManager.ts` with `casper-signer:` to reduce the risk of name collisions with other extensions.

I was able to delegate stake on testnet with the Keplr extension installed and account created.

### Asset
[Signer for PR 194](https://github.com/casper-ecosystem/signer/files/7748405/casperlabs_signer-1.4.7.zip)
