### PR TITLE
issue-201: `casper-js-sdk` updated to latest version (2.7.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.4.7",
+  "version": "1.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "casperlabs-signer",
-      "version": "1.4.7",
+      "version": "1.4.6",
       "dependencies": {
         "@babel/core": "^7.14.6",
         "@extend-chrome/storage": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casperlabs-signer",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "casperlabs-signer",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "dependencies": {
         "@babel/core": "^7.14.6",
         "@extend-chrome/storage": "^1.5.0",
@@ -26,7 +26,7 @@
         "@types/react-dom": "^16.9.14",
         "axios": "^0.21.1",
         "browser-passworder": "^2.0.3",
-        "casper-js-sdk": "^2.7.1",
+        "casper-js-sdk": "^2.7.5",
         "copy-to-clipboard": "^3.3.1",
         "download": "^8.0.0",
         "eslint-config-react-app": "^6.0.0",
@@ -2487,7 +2487,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -4356,6 +4355,14 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -7053,12 +7060,6 @@
       "engines": [
         "node >=0.10.0"
       ],
-      "dependencies": {
-        "dtrace-provider": "~0.8",
-        "moment": "^2.19.3",
-        "mv": "~2",
-        "safe-json-stringify": "~1"
-      },
       "bin": {
         "bunyan": "bin/bunyan"
       },
@@ -7299,15 +7300,16 @@
       "dev": true
     },
     "node_modules/casper-js-sdk": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/casper-js-sdk/-/casper-js-sdk-2.7.1.tgz",
-      "integrity": "sha512-vc9sXm4UEIjyMkxdsgy1QXiCW7uRg3+v6gSW2vhPk8shjtYdr/51Q+WrXy2cyqIc8a6/P/xiDGcLcOht+/AGIg==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/casper-js-sdk/-/casper-js-sdk-2.7.5.tgz",
+      "integrity": "sha512-SsQRARCxFFuycTEN+mq9IKNf7zv+Bc0mbWfKCR2woh0ucLN21hQigIWTKoIf7nsx58tNDJg4wgt4jhJfKJaFKg==",
       "dependencies": {
         "@ethersproject/bignumber": "^5.0.8",
         "@ethersproject/bytes": "^5.0.5",
         "@ethersproject/constants": "^5.0.5",
         "@open-rpc/client-js": "^1.6.2",
         "@types/eccrypto": "^1.1.2",
+        "@types/ws": "^8.2.2",
         "blakejs": "^1.1.0",
         "eccrypto": "^1.1.6",
         "eslint-plugin-prettier": "^3.4.0",
@@ -10060,8 +10062,7 @@
         "acorn": "7.1.1",
         "elliptic": "6.5.4",
         "es6-promise": "4.2.8",
-        "nan": "2.14.0",
-        "secp256k1": "3.7.1"
+        "nan": "2.14.0"
       },
       "optionalDependencies": {
         "secp256k1": "3.7.1"
@@ -10380,8 +10381,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -16012,7 +16012,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -23571,7 +23570,6 @@
         "eslint-webpack-plugin": "^2.5.2",
         "file-loader": "6.1.1",
         "fs-extra": "^9.0.1",
-        "fsevents": "^2.1.3",
         "html-webpack-plugin": "4.5.0",
         "identity-obj-proxy": "3.0.0",
         "jest": "26.6.0",
@@ -27900,10 +27898,8 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -28928,7 +28924,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -33956,6 +33951,14 @@
         }
       }
     },
+    "@types/ws": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "13.0.12",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
@@ -36497,15 +36500,16 @@
       "dev": true
     },
     "casper-js-sdk": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/casper-js-sdk/-/casper-js-sdk-2.7.1.tgz",
-      "integrity": "sha512-vc9sXm4UEIjyMkxdsgy1QXiCW7uRg3+v6gSW2vhPk8shjtYdr/51Q+WrXy2cyqIc8a6/P/xiDGcLcOht+/AGIg==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/casper-js-sdk/-/casper-js-sdk-2.7.5.tgz",
+      "integrity": "sha512-SsQRARCxFFuycTEN+mq9IKNf7zv+Bc0mbWfKCR2woh0ucLN21hQigIWTKoIf7nsx58tNDJg4wgt4jhJfKJaFKg==",
       "requires": {
         "@ethersproject/bignumber": "^5.0.8",
         "@ethersproject/bytes": "^5.0.5",
         "@ethersproject/constants": "^5.0.5",
         "@open-rpc/client-js": "^1.6.2",
         "@types/eccrypto": "^1.1.2",
+        "@types/ws": "^8.2.2",
         "blakejs": "^1.1.0",
         "eccrypto": "^1.1.6",
         "eslint-plugin-prettier": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/react-dom": "^16.9.14",
     "axios": "^0.21.1",
     "browser-passworder": "^2.0.3",
-    "casper-js-sdk": "^2.7.1",
+    "casper-js-sdk": "^2.7.5",
     "copy-to-clipboard": "^3.3.1",
     "download": "^8.0.0",
     "eslint-config-react-app": "^6.0.0",


### PR DESCRIPTION
Done:
- updated `casper-js-sdk` from 2.7.1 to 2.7.5 (latest now)
- checked `Import Account`, `Create account`, `Key Management`, `Connected Sites`, `Timeout` pages and `Locking by Timeout`, `Sign In`, `Download Active Key`, `Rename Account` functionalities