### PR TITLE
Amend locked event

### DIFF
--- a/src/background/utils.ts
+++ b/src/background/utils.ts
@@ -41,7 +41,7 @@ export function updateStatusEvent(appState: AppState, msg: eventType) {
         isUnlocked,
         isConnected: isUnlocked ? savedSite.isConnected : null,
         activeKey:
-          isConnected && isUnlocked && activeUserAccount
+          isConnected && activeUserAccount
             ? activeUserAccount.keyPair.publicKey.toHex()
             : null
       }


### PR DESCRIPTION
## Jist:

### Background:
When the Signer locks it wipes the state data it holds which is then recovered on Unlock.
The `signMessage()` function checks the public key (provided by the page) against keys held in appState to ensure we have the corresponding keypair.

### Issue
If the Signer is **Locked** when `signMessage()` is called then the checks fail every time because the appState is null. Regardless of whether the corresponding keypair is in there or not.

### Fix
1. Changes the events to include the active key when the Signer is locked, as long as it's Connected to the page. (This could even be reverted now that I've implemented 2.).
2. Changes the logic to not check if the key matches when it's locked. Instead I added a check that fires after the Signer has been unlocked.