### PR TITLE
[Integration]: casper.live #275

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -25,6 +25,8 @@
         "*://*.make.services/*",
         "*://cspr.live/*",
         "*://*.cspr.live/*",
+        "*://casper.live/*",
+        "*://*.casper.live/*",
         "*://casperholders.io/*",
         "*://*.casperholders.io/*",
         "*://casperholders.com/*",


### PR DESCRIPTION
This commit adds support for the casper.live alias URL of cspr.live


Signed-off-by: Michael Steuer <michael@make.software>