### PR TITLE
Corrects filename in CI workflow

### DIFF
--- a/.github/workflows/publish-casper-signer.yml
+++ b/.github/workflows/publish-casper-signer.yml
@@ -30,7 +30,7 @@ jobs:
       uses: trmcnvn/chrome-addon@v2
       with:
         extension: 'djhndpllfiibmcdbnmaaahkhchcoijce'
-        zip: artifacts/casper-signer-${{ steps.get_signer_version.outputs.version-without-v }}.zip
+        zip: artifacts/casper_signer-${{ steps.get_signer_version.outputs.version-without-v }}.zip
         client-id: ${{ secrets.client_id }}
         client-secret: ${{ secrets.client_secret }}
         refresh-token: ${{ secrets.refresh_token }}


### PR DESCRIPTION
The new name gets converted when packaging which converts it to lowercase and replaces spaces with underscores.

This needs to be reflected in the CI workflow.