### PR TITLE
Bump version to 1.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casper-signer",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "casper-signer",
-      "version": "1.4.10",
+      "version": "1.4.11",
       "dependencies": {
         "@babel/core": "^7.17.2",
         "@extend-chrome/storage": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-signer",
-  "version": "1.4.10",
+  "version": "1.4.11",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.17.2",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.4.10",
+  "version": "1.4.11",
   "name": "Casper Signer",
   "author": "https://casper.network",
   "description": "Casper Signer is the official non-custodial wallet that allows you to manage private keys and sign transactions on Casper Network",


### PR DESCRIPTION
Updates the version to 1.4.11 which should push the updated name through.

The name in `manifest.json` is **Casper Signer**, the name in the `package.json` is **casper-signer**. They are intentionally different as the `package` name has formatting requirements where the user-facing `manifest` name does not.