### PR TITLE
Add 127.0.0.1 to allowed sites manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -22,6 +22,7 @@
       "matches": [
         "*://*.casperlabs.io/*",
         "*://localhost/*",
+        "*://127.0.0.1/*",
         "*://*.make.services/*",
         "*://cspr.live/*",
         "*://*.cspr.live/*",


### PR DESCRIPTION
Hi Casper team,

I suggest to add 127.0.0.1 as allowed sites to have casperlabsHelper in window object otherwise it is a bit hard to understand why it is not defined on this loopback url. Not sure if this is the correct branch to PR though.

Regards