### PR TITLE
Bump package.json signer version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casper-signer",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "casper-signer",
-      "version": "1.4.26",
+      "version": "1.4.27",
       "dependencies": {
         "@babel/core": "^7.17.2",
         "@extend-chrome/storage": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-signer",
-  "version": "1.4.26",
+  "version": "1.4.27",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.17.2",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "1.4.26",
+  "version": "1.4.27",
   "name": "Casper Signer",
   "author": "https://casper.network",
   "description": "Casper Signer is the official non-custodial wallet that allows you to manage private keys and sign transactions on Casper Network",


### PR DESCRIPTION
Resolves package.json version

### Summary
Change to increment Casper Signer version from `1.4.26` to `1.4.27` in `package.json` and `package-lock.json`

### TODO

- [x] N/A.

### Checklist

- [x] Code is properly formatted - Yes
- [x] Tests included/updated or not needed - Not needed
- [x] Documentation has been updated or is not required - Not required

### Build artifact for QA: Please refer commit details. 

